### PR TITLE
Fixed a typo in the basic usage example.

### DIFF
--- a/docs/usage/basics.rst
+++ b/docs/usage/basics.rst
@@ -11,7 +11,7 @@ Authentication
 
 The :class:`TwilioRestClient` needs your Twilio credentials. While these can be passed in directly to the constructor, we suggest storing your credentials as environment variables. Why? You'll never have to worry about committing your credentials and accidentally posting them somewhere public.
 
-The :class:`TwilioClient` looks for :const:`TWILIO_ACCOUT_SID` and :const:`TWILIO_AUTH_TOKEN` inside the current environment.
+The :class:`TwilioClient` looks for :const:`TWILIO_ACCOUNT_SID` and :const:`TWILIO_AUTH_TOKEN` inside the current environment.
 
 With those two values set, create a new :class:`TwilioClient`.
 
@@ -27,7 +27,7 @@ If you'd rather not use environment variables, pass your account credentials dir
 
     from twilio.rest import TwilioRestClient
 
-    ACCOUT_SID = "AXXXXXXXXXXXXXXXXX"
+    ACCOUNT_SID = "AXXXXXXXXXXXXXXXXX"
     AUTH_TOKEN = "YYYYYYYYYYYYYYYYYY"
     client = TwilioRestClient(ACCOUNT_SID, AUTH_TOKEN)
 


### PR DESCRIPTION
The example (and the description above it) referred to "ACCOUT_SID". It should be "ACCOUNT_SID".
