### PR TITLE
Remove parens from import statement in getting started guide

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -11,7 +11,11 @@ Making a Call
 
     from twilio.rest import TwilioRestClient
 
-    client = TwilioRestClient()
+    # To find these visit https://www.twilio.com/user/account
+    ACCOUNT_SID = "ACXXXXXXXXXXXXXXXXX"
+    AUTH_TOKEN = "YYYYYYYYYYYYYYYYYY"
+
+    client = TwilioRestClient(ACCOUNT_SID, AUTH_TOKEN)
     call = client.calls.make(to="9991231234", from_="9991231234",
                              url="http://foo.com/call.xml")
     print call.length

--- a/twilio/rest/__init__.py
+++ b/twilio/rest/__init__.py
@@ -93,7 +93,21 @@ class TwilioRestClient(object):
         if not account or not token:
             account, token = find_credentials()
             if not account or not token:
-                raise TwilioException("Could not find account credentials")
+                raise TwilioException("""
+Twilio could not find your account credentials. Pass them into the
+TwilioRestClient constructor like this:
+
+    client = TwilioRestClient(account='AC38135355602040856210245275870',
+                              token='2flnf5tdp7so0lmfdu3d')
+
+Or, add your credentials to your shell environment. From the terminal, run
+
+    echo "export TWILIO_ACCOUNT_SID=AC3813535560204085626521" >> ~/.bashrc
+    echo "export TWILIO_AUTH_TOKEN=2flnf5tdp7so0lmfdu3d7wod" >> ~/.bashrc
+
+and be sure to replace the values for the Account SID and auth token with the
+values from your Twilio Account at https://www.twilio.com/user/account.
+""")
 
         auth = (account, token)
         version_uri = "%s/%s" % (base, version)


### PR DESCRIPTION
Hey, this is a pretty simple change - the import statement in the Getting Started guide has a () but it shouldn't have one.
