### PR TITLE
More detailed error message on failure and working quickstart code

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -11,7 +11,11 @@ Making a Call
 
     from twilio.rest import TwilioRestClient
 
-    client = TwilioRestClient()
+    # To find these visit https://www.twilio.com/user/account
+    ACCOUNT_SID = "ACXXXXXXXXXXXXXXXXX"
+    AUTH_TOKEN = "YYYYYYYYYYYYYYYYYY"
+
+    client = TwilioRestClient(ACCOUNT_SID, AUTH_TOKEN)
     call = client.calls.make(to="9991231234", from_="9991231234",
                              url="http://foo.com/call.xml")
     print call.length

--- a/twilio/rest/__init__.py
+++ b/twilio/rest/__init__.py
@@ -93,7 +93,21 @@ class TwilioRestClient(object):
         if not account or not token:
             account, token = find_credentials()
             if not account or not token:
-                raise TwilioException("Could not find account credentials")
+                raise TwilioException("""
+Twilio could not find your account credentials. Pass them into the
+TwilioRestClient constructor like this:
+
+    client = TwilioRestClient(account='AC38135355602040856210245275870',
+                              token='2flnf5tdp7so0lmfdu3d')
+
+Or, add your credentials to your shell environment. From the terminal, run
+
+    echo "export TWILIO_ACCOUNT_SID=AC3813535560204085626521" >> ~/.bashrc
+    echo "export TWILIO_AUTH_TOKEN=2flnf5tdp7so0lmfdu3d7wod" >> ~/.bashrc
+
+and be sure to replace the values for the Account SID and auth token with the
+values from your Twilio Account at https://www.twilio.com/user/account.
+""")
 
         auth = (account, token)
         version_uri = "%s/%s" % (base, version)


### PR DESCRIPTION
Currently if you follow the quickstart code (which also assumes you've already run `pip install twilio`) exactly as written, you get the following error message:

```
>>> from twilio.rest import TwilioRestClient
>>> client = TwilioRestClient()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "twilio/rest/__init__.py", line 96, in __init__
    raise TwilioException("Could not find account credentials")
twilio.TwilioException: Could not find account credentials
```

This is unhelpful and doesn't tell you what you need to do to solve the problem. In addition the quickstart doesn't really tell how to add your credentials either. I added a more detailed error message and more code to the quickstart, so that running the quickstart code will produce a result.

In the future you/we might want to change the next line of the quickstart from calling to SMS so that someone running through the quickstart can immediately punch in their phone number and get a text message, instead of having to upload XML somewhere and figure out how to do that too.
