### PR TITLE
Set Sms Application, Voice Application, and/or a Friendly Name when purchasing a number.

### DIFF
--- a/twilio/rest/resources.py
+++ b/twilio/rest/resources.py
@@ -859,7 +859,8 @@ class PhoneNumbers(ListResource):
                  status_callback_url=None, status_callback_method=None,
                  sms_url=None, sms_method=None, sms_fallback_url=None,
                  sms_fallback_method=None, voice_caller_id_lookup=None,
-                 account_sid=None, application_sid=None):
+                 account_sid=None, sms_application_sid=None,
+                 voice_application_sid=None, friendly_name=None):
         """
         Attempt to purchase the specified number. The only required parameters
         are **either** phone_number or area_code
@@ -880,7 +881,9 @@ class PhoneNumbers(ListResource):
                 "StatusCallbackMethod": status_callback_method,
                 "VoiceCallerIdLookup": voice_caller_id_lookup,
                 "AccountSid": account_sid,
-                "ApplicationSid": application_sid,
+                "SmsApplicationSid": sms_application_sid,
+                "VoiceApplicationSid": voice_application_sid,
+                "FriendlyName": friendly_name,
                })
 
         if phone_number:


### PR DESCRIPTION
Per Twilio Rest Docs, you should be able to set the Sms Application, Voice Application, as well as a "Friendly Name". Friendly Name was in a previous version of this library when purchasing a number, but seems to have been lost. Also, I removed the ApplicationSid parameter, I didn't see it being used anywhere.
