### PR TITLE
Removed extraneous print statement in twiml

### DIFF
--- a/twilio/twiml.py
+++ b/twilio/twiml.py
@@ -81,7 +81,6 @@ class Verb(object):
         return el
 
     def append(self, verb):
-        print self.nestables
         if not self.nestables or verb.name not in self.nestables:
             raise TwimlException("%s is not nestable inside %s" % \
                 (verb.name, self.name))


### PR DESCRIPTION
I think someone forgot an extra print statement in twiml. I had to remove it to use the library in a CGI app.
