### PR TITLE
Version guidelines

### DIFF
--- a/bumping_version.md
+++ b/bumping_version.md
@@ -14,3 +14,22 @@ Checklist:
         git tag latest
         git push upstream --tags
 
+* Upload to PyPI. You need a `~/.pypirc` file with this in it:
+
+        [pypirc]
+        servers =
+            pypi
+
+        [server-login]
+        username:<username>
+        password:<password>
+
+    You can get the username and password from someone who has them.
+
+    Then run:
+
+        python setup.py sdist
+
+    If you are satisfied with the output, upload to PyPI:
+
+        python setup.py sdist upload


### PR DESCRIPTION
add instructions on how to bump versions, as well as a checklist
