### PR TITLE
consistent whitespace across the .rst docs, some minor corrections

### DIFF
--- a/docs/api/twiml.rst
+++ b/docs/api/twiml.rst
@@ -7,6 +7,7 @@
 .. autoclass:: twilio.twiml.Response
    :members:
 
+
 Primary Verbs
 ~~~~~~~~~~~~~
 
@@ -24,6 +25,7 @@ Primary Verbs
 
 .. autoclass:: twilio.twiml.Record
    :members:
+
 
 Secondary Verbs
 ~~~~~~~~~~~~~~~
@@ -49,6 +51,7 @@ Secondary Verbs
 .. autoclass:: twilio.twiml.Leave
    :members:
 
+
 Nouns
 ~~~~~~
 
@@ -63,3 +66,4 @@ Nouns
 
 .. autoclass:: twilio.twiml.Queue
    :members:
+

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -5,6 +5,7 @@ Frequently Asked Questions
 Hopefully you can find an answer here to one of your questions. If not, please
 contact `help@twilio.com <mailto:help@twilio.com>`_.
 
+
 ImportError messages
 --------------------
 
@@ -15,13 +16,13 @@ If you get an error that looks like this:
     Traceback (most recent call last):
       File "twilio.py", line 1, in <module>
         from twilio.rest import TwilioRestClient
-      File "/Users/kevin/code/twilio-python/docs/twilio.py", line 1, in <module>
+      File "/.../twilio-python/docs/twilio.py", line 1, in <module>
         from twilio.rest import TwilioRestClient
     ImportError: No module named rest
 
-Check to make sure that you don't have a file named ``twilio.py``; Python will try to
-load the Twilio library from your ``twilio.py`` file instead of from the Twilio
-library.
+Check to make sure that you don't have a file named ``twilio.py``;
+Python will try to load the Twilio library from your ``twilio.py`` file
+instead of from the Twilio library.
 
 If you get an error that looks like this:
 
@@ -49,8 +50,8 @@ grep pip`` (works with Bash on \*nix machines). There can also be more than one
 version of Python, especially if you have Macports or homebrew.
 
 You also may be using an outdated version of the twilio-python library, which
-did not use a ``twilio.rest.TwilioRestClient`` object. Check which version of the
-twilio library you have installed by running this command:
+did not use a ``twilio.rest.TwilioRestClient`` object. Check which version of
+the twilio library you have installed by running this command:
 
 .. code-block:: bash
 
@@ -65,6 +66,7 @@ version, you can upgrade with this command:
 
 Note that if you have code that uses the older version of the library, it may
 break when you upgrade your site.
+
 
 Formatting phone numbers
 ------------------------
@@ -99,7 +101,7 @@ Then you can convert user input to phone numbers like this:
             # Phone number may already be in E.164 format.
             parse_type = None
         else:
-            # If no country code information is present, assume it's a US number
+            # If no country code information present, assume it's a US number
             parse_type = "US"
 
         phone_representation = phonenumbers.parse(raw_phone, parse_type)
@@ -107,5 +109,4 @@ Then you can convert user input to phone numbers like this:
             phonenumbers.PhoneNumberFormat.E164)
 
     print convert_to_e164('212 555 1234')   # prints +12125551234
-
 

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -6,6 +6,7 @@ Getting started with the Twilio API couldn't be easier. Create a Twilio REST
 client to get started. For example, the following code makes a call using the
 Twilio REST API.
 
+
 Make a Call
 ===============
 
@@ -19,9 +20,10 @@ Make a Call
 
     client = TwilioRestClient(ACCOUNT_SID, AUTH_TOKEN)
     call = client.calls.create(to="9991231234", from_="9991231234",
-                               url="http://twimlets.com/holdmusic?Bucket=com.twilio.music.ambient")
+        url="http://twimlets.com/holdmusic?Bucket=com.twilio.music.ambient")
     print call.length
     print call.sid
+
 
 Send an SMS
 ================
@@ -34,8 +36,10 @@ Send an SMS
     token = "YYYYYYYYYYYYYYYYYY"
     client = TwilioRestClient(account, token)
 
-    message = client.sms.messages.create(to="+12316851234", from_="+15555555555",
+    message = client.sms.messages.create(to="+12316851234",
+                                         from_="+15555555555",
                                          body="Hello there!")
+
 
 Generating TwiML
 =================
@@ -55,7 +59,10 @@ to easily create such responses.
 .. code-block:: xml
 
     <?xml version="1.0" encoding="utf-8"?>
-    <Response><Play loop="5">https://api.twilio.com/cowbell.mp3</Play><Response>
+    <Response>
+        <Play loop="5">https://api.twilio.com/cowbell.mp3</Play>
+    <Response>
+
 
 Digging Deeper
 ========================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,8 +1,11 @@
-====================
+============================
 Twilio Python Helper Library
-====================
+============================
 
-Make requests to Twilio's `REST API <http://www.twilio.com/docs/api/twiml/>`_ and create `TwiML <http://www.twilio.com/docs/api/twiml/>`_ without a hassle. And you thought Twilio couldn't get any easier.
+Make requests to Twilio's `REST API <http://www.twilio.com/docs/api/twiml/>`_
+and create `TwiML <http://www.twilio.com/docs/api/twiml/>`_ without a hassle.
+And you thought Twilio couldn't get any easier.
+
 
 .. _installation:
 
@@ -23,28 +26,40 @@ line:
 
     $ curl https://raw.github.com/pypa/pip/master/contrib/get-pip.py | python
 
-Or, install the library by `downloading the source <https://github.com/twilio/twilio-python/zipball/master>`_, installing :data:`setuptools`, navigating in the Terminal to the folder containing the **twilio-python** library, and then running:
+Or, install the library by downloading
+`the source <https://github.com/twilio/twilio-python/zipball/master>`_,
+installing :data:`setuptools`,
+navigating in the Terminal to the folder containing the **twilio-python**
+library, and then running:
 
 .. code-block:: bash
 
     $ python setup.py install
 
+
 Getting Started
 ================
 
-The :doc:`/getting-started` will get you up and running in a few quick minutes. This guide assumes you understand the core concepts of Twilio. If you've never used Twilio before, don't fret! Just read `about how Twilio works <http://www.twilio.com/api/>`_ and then jump in.
+The :doc:`/getting-started` will get you up and running in a few quick minutes.
+This guide assumes you understand the core concepts of Twilio.
+If you've never used Twilio before, don't fret! Just read
+`about how Twilio works <http://www.twilio.com/api/>`_ and then jump in!
+
 
 .. _user-guide:
 
 User Guide
 ==================
 
-Functionality is split over three different sub-packages within **twilio-python**. Below are in-depth guides to specific portions of the library.
+Functionality is split over three different sub-packages within
+**twilio-python**. Below are in-depth guides to specific portions of the
+library.
+
 
 REST API
 ----------
 
-Query the Twilio REST API to create phone calls, send SMS messages and so much more
+Query the Twilio REST API to create phone calls, send SMS messages and more!
 
 .. toctree::
     :maxdepth: 1
@@ -61,6 +76,8 @@ Query the Twilio REST API to create phone calls, send SMS messages and so much m
     usage/transcriptions
     usage/caller-ids
     usage/queues
+
+
 TwiML
 ---------
 
@@ -70,6 +87,7 @@ Generates valid TwiML for controlling and manipulating phone calls.
     :maxdepth: 2
 
     usage/twiml
+
 
 Utilities
 ----------
@@ -82,12 +100,14 @@ Small functions useful for validating requests are coming from Twilio
     usage/validation
     usage/token-generation
 
+
 Upgrade Plan
 ==================
 
 `twilio-python` 3.0 introduced backwards-incompatible changes to the API. See
 the :doc:`/upgrade-guide` for step-by-step instructions for migrating to 3.0.
 In many cases, the same methods are still offered, just in different locations.
+
 
 API Reference
 ==================
@@ -100,6 +120,7 @@ so only use when you really need to dive deep into the library.
 
     api
 
+
 Frequently Asked Questions
 ==========================
 
@@ -111,17 +132,22 @@ phone numbers.
 
     faq
 
+
 Support and Development
 ==========================
-All development occurs over on `Github <https://github.com/twilio/twilio-python>`_. To checkout the source,
+All development occurs over on
+`Github <https://github.com/twilio/twilio-python>`_. To checkout the source,
 
 .. code-block:: bash
 
     $ git clone git@github.com:twilio/twilio-python.git
 
 
-Report bugs using the Github `issue tracker <https://github.com/twilio/twilio-python/issues>`_.
+Report bugs using the Github
+`issue tracker <https://github.com/twilio/twilio-python/issues>`_.
 
-If you have questions that aren't answered by this documentation, ask the `#twilio IRC channel <irc://irc.freenode.net/#twilio>`_
+If you have questions that aren't answered by this documentation,
+ask the `#twilio IRC channel <irc://irc.freenode.net/#twilio>`_
 
 See the :doc:`/changelog` for version history.
+

--- a/docs/upgrade-guide.rst
+++ b/docs/upgrade-guide.rst
@@ -2,12 +2,18 @@
 Upgrade Guide
 ==============
 
-Porting your application from **twilio-python** 2.0 to 3.0 is straightforward. All the same methods are still offered. Only their location has changed.
+Porting your application from **twilio-python** 2.0 to 3.0 is straightforward.
+All the same methods are still offered. Only their location has changed.
+
 
 Making API Requests
 ====================
 
-:class:`twilio.Account` has been moved to :class:`twilio.rest.TwilioRestClient`. The rest client offers a greatly improved API; however, the old :meth:`request` method still exists (in a deprecated state). We suggest you migrate your code to use the new API.
+:class:`twilio.Account` has been moved to
+:class:`twilio.rest.TwilioRestClient`.
+The rest client offers a greatly improved API;
+however, the old :meth:`request` method still exists (in a deprecated state).
+We suggest you migrate your code to use the new API.
 
 Here is how you would place an outgoing call with the older version.
 
@@ -29,15 +35,16 @@ Here is how you would place an outgoing call with the older version.
     account = twilio.Account(ACCOUNT_SID, ACCOUNT_TOKEN)
 
     d = {
-        'From' : CALLER_ID,
-        'To' : '415-555-1212',
-        'Url' : 'http://twimlets.com/holdmusic?Bucket=com.twilio.music.ambient',
+        'From': CALLER_ID,
+        'To': '415-555-1212',
+        'Url': 'http://twimlets.com/holdmusic?Bucket=com.twilio.music.ambient',
     }
 
-    print account.request('/%s/Accounts/%s/Calls' % \
+    print account.request('/%s/Accounts/%s/Calls' %
                          (API_VERSION, ACCOUNT_SID), 'POST', d)
 
-The same code, updated to work with the new version (albeit using deprecated methods).
+The same code, updated to work with the new version
+(albeit using deprecated methods).
 
 .. code-block:: python
 
@@ -51,12 +58,12 @@ The same code, updated to work with the new version (albeit using deprecated met
     client = TwilioRestClient(ACCOUNT_SID, ACCOUNT_TOKEN)
 
     d = {
-        'From' : CALLER_ID,
-        'To' : '415-555-1212',
-        'Url' : 'http://twimlets.com/holdmusic?Bucket=com.twilio.music.ambient',
+        'From': CALLER_ID,
+        'To': '415-555-1212',
+        'Url': 'http://twimlets.com/holdmusic?Bucket=com.twilio.music.ambient',
     }
 
-    print client.request('/%s/Accounts/%s/Calls' % \
+    print client.request('/%s/Accounts/%s/Calls' %
                         (API_VERSION, ACCOUNT_SID), 'POST', d)
 
 A final version using the new interface.
@@ -70,7 +77,7 @@ A final version using the new interface.
 
     client = TwilioRestClient(ACCOUNT_SID, ACCOUNT_TOKEN)
     call = client.calls.create(from_='NNNNNNNNNN', to='415-555-1212',
-                               url='http://twimlets.com/holdmusic?Bucket=com.twilio.music.ambient')
+        url='http://twimlets.com/holdmusic?Bucket=com.twilio.music.ambient')
 
     print call
 

--- a/docs/usage/accounts.rst
+++ b/docs/usage/accounts.rst
@@ -4,15 +4,19 @@
 Accounts
 ===========
 
-Managing Twilio accounts is straightforward. Update your own account information or create and manage multiple subaccounts.
+Managing Twilio accounts is straightforward.
+Update your own account information or create and manage multiple subaccounts.
 
-For more information, see the `Account REST Resource <http://www.twilio.com/docs/api/rest/account>`_ documentation.
+For more information, see the
+`Account REST Resource <http://www.twilio.com/docs/api/rest/account>`_
+documentation.
 
 
 Updating Account Information
 ----------------------------
 
-Use the :meth:`Account.update` to modify one of your accounts. Right now the only valid attribute is `FriendlyName`.
+Use the :meth:`Account.update` to modify one of your accounts.
+Right now the only valid attribute is `FriendlyName`.
 
 .. code-block:: python
 
@@ -25,6 +29,7 @@ Use the :meth:`Account.update` to modify one of your accounts. Right now the onl
     client = TwilioRestClient(ACCOUNT_SID, AUTH_TOKEN)
     account = client.accounts.get(ACCOUNT_SID)
     account.update(friendly_name="My Awesome Account")
+
 
 Creating Subaccounts
 ----------------------
@@ -41,6 +46,7 @@ Subaccounts are easy to make.
 
     client = TwilioRestClient(ACCOUNT_SID, AUTH_TOKEN)
     subaccount = client.accounts.create(name="My Awesome SubAccount")
+
 
 Managing Subaccounts
 -------------------------

--- a/docs/usage/applications.rst
+++ b/docs/usage/applications.rst
@@ -4,9 +4,13 @@
 Applications
 =================
 
-An application inside of Twilio is just a set of URLs and other configuration data that tells Twilio how to behave when one of your Twilio numbers receives a call or SMS message.
+An application inside of Twilio is just a set of URLs and other configuration
+data that tells Twilio how to behave when one of your Twilio numbers receives
+a call or SMS message.
 
-For more information, see the `Application REST Resource <http://www.twilio.com/docs/api/rest/applications>`_ documentation.
+For more information, see the `Application REST Resource
+<http://www.twilio.com/docs/api/rest/applications>`_ documentation.
+
 
 Listing Your Applications
 --------------------------
@@ -42,6 +46,7 @@ You can filter applications by FriendlyName
     client = TwilioRestClient(ACCOUNT_SID, AUTH_TOKEN)
     for app in client.applications.list(friendly_name="FOO"):
         print app.sid
+
 
 Creating an Application
 -------------------------
@@ -93,3 +98,4 @@ Deleting an Application
     app_sid = 'AP123' # the app you'd like to delete
     client = TwilioRestClient(ACCOUNT_SID, AUTH_TOKEN)
     client.applications.delete(app_sid)
+

--- a/docs/usage/basics.rst
+++ b/docs/usage/basics.rst
@@ -4,7 +4,8 @@
 Accessing REST Resources
 =========================
 
-To access Twilio REST resources, you'll first need to instantiate a :class:`TwilioRestClient`.
+To access Twilio REST resources, you'll first need to instantiate a
+:class:`TwilioRestClient`.
 
 Authentication
 --------------------------
@@ -14,7 +15,8 @@ passed in directly to the constructor, we suggest storing your credentials as
 environment variables. Why? You'll never have to worry about committing your
 credentials and accidentally posting them somewhere public.
 
-The :class:`TwilioRestClient` looks for :const:`TWILIO_ACCOUNT_SID` and :const:`TWILIO_AUTH_TOKEN` inside the current environment.
+The :class:`TwilioRestClient` looks for :const:`TWILIO_ACCOUNT_SID` and
+:const:`TWILIO_AUTH_TOKEN` inside the current environment.
 
 With those two values set, create a new :class:`TwilioClient`.
 
@@ -39,7 +41,9 @@ directly to the the constructor.
 Listing Resources
 -------------------
 
-The :class:`TwilioRestClient` gives you access to various list resources. :meth:`ListResource.list`, by default, returns the most recent 50 instance resources.
+The :class:`TwilioRestClient` gives you access to various list resources.
+:meth:`ListResource.list`, by default, returns the most recent 50 instance
+resources.
 
 .. code-block:: python
 
@@ -52,7 +56,8 @@ The :class:`TwilioRestClient` gives you access to various list resources. :meth:
     client = TwilioRestClient(ACCOUNT_SID, AUTH_TOKEN)
     resources = client.calls.list()
 
-:meth:`resource.ListResource.list` accepts paging arguments. The following will return page 3 with page size of 25.
+:meth:`resource.ListResource.list` accepts paging arguments.
+The following will return page 3 with page size of 25.
 
 .. code-block:: python
 
@@ -69,7 +74,11 @@ The :class:`TwilioRestClient` gives you access to various list resources. :meth:
 Listing All Resources
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-Sometimes you'd like to retrieve all records from a list resource. Instead of manually paging over the resource, the :class:`resources.ListResource.iter` method returns a generator. After exhausting the current page, the generator will request the next page of results.
+Sometimes you'd like to retrieve all records from a list resource.
+Instead of manually paging over the resource,
+the :class:`resources.ListResource.iter` method returns a generator.
+After exhausting the current page,
+the generator will request the next page of results.
 
 .. warning:: Accessing all your records can be slow. We suggest only doing so when you absolutely need all the records
 
@@ -89,7 +98,9 @@ Sometimes you'd like to retrieve all records from a list resource. Instead of ma
 Get an Individual Resource
 -----------------------------
 
-To get an individual instance resource, use :class:`resources.ListResource.get`. Provide the :attr:`sid` of the resource you'd like to get.
+To get an individual instance resource, use
+:meth:`resources.ListResource.get`.
+Provide the :attr:`sid` of the resource you'd like to get.
 
 .. code-block:: python
 

--- a/docs/usage/caller-ids.rst
+++ b/docs/usage/caller-ids.rst
@@ -4,6 +4,7 @@
 Caller Ids
 =================
 
+
 Validate a Phone Number
 -----------------------
 

--- a/docs/usage/conferences.rst
+++ b/docs/usage/conferences.rst
@@ -6,6 +6,7 @@ Conferences and Participants
 
 For more information, see the `Conference REST Resource <http://www.twilio.com/docs/api/rest/conference>`_ and `Participant REST Resource <http://www.twilio.com/docs/api/rest/participant>`_ documentation.
 
+
 Listing Conferences
 -----------------------
 
@@ -22,6 +23,7 @@ Listing Conferences
 
     for conference in conferences:
         print conference.sid
+
 
 Filtering Conferences
 -----------------------
@@ -62,6 +64,10 @@ Each :class:`Conference` has a :attr:`participants` instance which represents al
     for participant in conference.participants.list():
         print participant.sid
 
+:class:`Conferences` and :class:`Participants` are subclasses of :class:`ListResource`.
+Therefore, their instances have the inherited methods such as :meth:`count`.
+
+
 Managing Participants
 ----------------------
 
@@ -93,3 +99,4 @@ code kicks out the first participant and mutes the rest.
     # And mute the rest
     for participant in participants:
         participant.mute()
+

--- a/docs/usage/messages.rst
+++ b/docs/usage/messages.rst
@@ -1,10 +1,13 @@
-.. module:: twilio.rest.resources
+.. module:: twilio.rest.resources.sms_messages
 
 ============
 SMS Messages
 ============
 
-For more information, see the `SMS Message REST Resource <http://www.twilio.com/docs/api/rest/sms>`_ documentation.
+For more information, see the
+`SMS Message REST Resource <http://www.twilio.com/docs/api/rest/sms>`_
+documentation.
+
 
 Sending a Text Message
 ----------------------
@@ -53,7 +56,9 @@ Retrieving Sent Messages
 Filtering Your Messages
 -------------------------
 
-The :meth:`list` methods supports filtering on :attr:`to`, :attr:`from_`, and :attr:`date_sent`. The following will only show messages to "+5466758723" on January 1st, 2011.
+The :meth:`list` methods supports filtering on :attr:`to`, :attr:`from_`,
+and :attr:`date_sent`.
+The following will only show messages to "+5466758723" on January 1st, 2011.
 
 .. code-block:: python
 
@@ -71,5 +76,4 @@ The :meth:`list` methods supports filtering on :attr:`to`, :attr:`from_`, and :a
 
     for message in messages:
         print message.body
-
 

--- a/docs/usage/notifications.rst
+++ b/docs/usage/notifications.rst
@@ -4,12 +4,15 @@
 Notifications
 ====================
 
-For more information, see the `Notifications REST Resource <http://www.twilio.com/docs/api/rest/notification>`_ documentation.
+For more information, see the `Notifications REST Resource
+<http://www.twilio.com/docs/api/rest/notification>`_ documentation.
+
 
 Listing Your Notifications
 ----------------------------
 
-The following code will print out additional information about each of your current :class:`Notification` resources.
+The following code will print out additional information about each of your
+current :class:`Notification` resources.
 
 .. code-block:: python
 
@@ -23,7 +26,8 @@ The following code will print out additional information about each of your curr
     for notification in client.notifications.list():
         print notification.more_info
 
-You can filter transcriptions by :attr:`log` and :attr:`message_date`. The :attr:`log` value is 0 for `ERROR` and 1 for `WARNING`.
+You can filter transcriptions by :attr:`log` and :attr:`message_date`.
+The :attr:`log` value is 0 for `ERROR` and 1 for `WARNING`.
 
 .. code-block:: python
 
@@ -40,12 +44,17 @@ You can filter transcriptions by :attr:`log` and :attr:`message_date`. The :attr
     for notification in client.notifications.list(log=ERROR):
         print notification.error_code
 
-.. note:: Due to the potentially voluminous amount of data in a notification, the full HTTP request and response data is only returned in the :class:`Notification` instance resource representation.
+.. note:: Due to the potentially voluminous amount of data in a notification,
+    the full HTTP request and response data is only returned in the
+    :class:`Notification` instance resource representation.
+
 
 Deleting Notifications
 ------------------------
 
-Your account can sometimes generate an inordinate amount of :class:`Notification` resources. The :class:`Notifications` resource allows you to delete unnecessary notifications.
+Your account can sometimes generate an inordinate amount of
+:class:`Notification` resources. The :class:`Notifications` resource allows
+you to delete unnecessary notifications.
 
 .. code-block:: python
 

--- a/docs/usage/phone-calls.rst
+++ b/docs/usage/phone-calls.rst
@@ -7,6 +7,7 @@ Phone Calls
 The :class:`Calls` resource manages all interaction with Twilio phone calls,
 including the creation and termination of phone calls.
 
+
 Making a Phone Call
 -------------------
 
@@ -28,10 +29,12 @@ can be successfully started, you'll need a url which outputs valid `TwiML
     print call.length
     print call.sid
 
+
 Retrieve a Call Record
 -------------------------
 
-If you already have a :class:`Call` sid, you can use the client to retrieve that record.
+If you already have a :class:`Call` sid,
+you can use the client to retrieve that record.
 
 .. code-block:: python
 
@@ -45,10 +48,14 @@ If you already have a :class:`Call` sid, you can use the client to retrieve that
     sid = "CA12341234"
     call = client.calls.get(sid)
 
-Accessing Specific Call Resources
->>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
-Each :class:`Call` resource also has access to its `notifications`, `recordings`, and `transcriptions`. These attributes are :class:`ListResources`, just like the :class:`Calls` resource itself.
+Accessing Specific Call Resources
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Each :class:`Call` resource also has access to its `notifications`,
+`recordings`, and `transcriptions`.
+These attributes are :class:`ListResources`,
+just like the :class:`Calls` resource itself.
 
 .. code-block:: python
 
@@ -66,7 +73,9 @@ Each :class:`Call` resource also has access to its `notifications`, `recordings`
     print call.recordings.list()
     print call.transcriptions.list()
 
-However, what if you only have a `CallSid`, and not the actual :class:`Resource`? No worries, as :meth:`list` can be filter based on `CallSid`.
+However, what if you only have a `CallSid`,
+and not the actual :class:`Resource`? No worries,
+as :meth:`list` can be filter based on `CallSid`.
 
 .. code-block:: python
 
@@ -86,7 +95,8 @@ However, what if you only have a `CallSid`, and not the actual :class:`Resource`
 Modifying Live Calls
 --------------------
 
-The :class:`Call` resource makes it easy to find current live calls and redirect them as necessary
+The :class:`Call` resource makes it easy to find current live calls and
+redirect them as necessary
 
 .. code-block:: python
 
@@ -100,8 +110,10 @@ The :class:`Call` resource makes it easy to find current live calls and redirect
     client = TwilioRestClient(ACCOUNT_SID, AUTH_TOKEN)
     calls = client.calls.list(status=Call.IN_PROGRESS)
     for c in calls:
-        c.route("http://twimlets.com/holdmusic?Bucket=com.twilio.music.ambient", 
-                method="POST")
+        c.route(
+            "http://twimlets.com/holdmusic?Bucket=com.twilio.music.ambient",
+            method="POST"
+        )
 
 Ending all live calls is also possible
 
@@ -134,9 +146,8 @@ resource to update the record without having to use :meth:`get` first.
 
     client = TwilioRestClient(ACCOUNT_SID, AUTH_TOKEN)
     sid = "CA12341234"
-    client.calls.update(sid, 
-                        url="http://twimlets.com/holdmusic?Bucket=com.twilio.music.ambient", 
-                        method="POST")
+    client.calls.update(sid, method="POST",
+        url="http://twimlets.com/holdmusic?Bucket=com.twilio.music.ambient")
 
 Hanging up the call also works.
 
@@ -151,3 +162,4 @@ Hanging up the call also works.
     client = TwilioRestClient(ACCOUNT_SID, AUTH_TOKEN)
     sid = "CA12341234"
     client.calls.hangup(sid)
+

--- a/docs/usage/phone-numbers.rst
+++ b/docs/usage/phone-numbers.rst
@@ -6,13 +6,17 @@ Phone Numbers
 
 With Twilio you can search and buy real phone numbers, just using the API.
 
-For more information, see the `IncomingPhoneNumbers REST Resource <http://www.twilio.com/docs/api/rest/incoming-phone-numbers>`_ documentation.
+For more information, see the
+`IncomingPhoneNumbers REST Resource
+<http://www.twilio.com/docs/api/rest/incoming-phone-numbers>`_ documentation.
 
 
 Searching and Buying a Number
 --------------------------------
 
-Finding numbers to buy couldn't be easier. We first search for a number in area code 530. Once we find one, we'll purchase it for our account.
+Finding numbers to buy couldn't be easier.
+We first search for a number in area code 530.
+Once we find one, we'll purchase it for our account.
 
 .. code-block:: python
 
@@ -30,11 +34,12 @@ Finding numbers to buy couldn't be easier. We first search for a number in area 
     else:
         print "No numbers in 530 available"
 
+
 Toll Free Numbers
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-By default, :meth:`PhoneNumbers.search` looks for local phone numbers. Set :data:`type` to
-``tollfree`` to search toll-free numbers instead.
+By default, :meth:`PhoneNumbers.search` looks for local phone numbers.
+Set :data:`type` to ``tollfree`` to search toll-free numbers instead.
 
 .. code-block:: python
 
@@ -44,7 +49,8 @@ By default, :meth:`PhoneNumbers.search` looks for local phone numbers. Set :data
 Numbers Containing Words
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Phone number search also supports looking for words inside phone numbers. The following example will find any phone number with "FOO" in it.
+Phone number search also supports looking for words inside phone numbers.
+The following example will find any phone number with "FOO" in it.
 
 .. code-block:: python
 
@@ -60,6 +66,7 @@ You can use the ''*'' wildcard to match any character. The following example fin
 to augment your search. The `AvailablePhoneNumbers REST Resource
 <http://www.twilio.com/docs/api/rest/available-phone-numbers>`_ documentation
 also documents the various search options.
+
 
 Buying a Number
 ---------------
@@ -80,8 +87,9 @@ If you've found a phone number you want, you can purchase the number.
 However, it's easier to purchase numbers after finding them using search (as
 shown in the first example).
 
+
 Updating Properties on a Number
-------------------
+-------------------------------
 
 To update the properties on a phone number, call :meth:`update`
 on the phone number object, with any of the parameters
@@ -102,6 +110,7 @@ listed in the `IncomingPhoneNumbers Resource documentation
             "Bucket=com.twilio.music.ambient", 
             status_callback="http://example.com/callback")
 
+
 Changing Applications
 ----------------------
 
@@ -121,6 +130,7 @@ An :class:`Application` encapsulates all necessary URLs for use with phone numbe
     number = client.phone_numbers.update(phone_sid, sms_application_sid="AP123")
 
 See :doc:`/usage/applications` for instructions on updating and maintaining Applications.
+
 
 Validate a Phone Number
 -----------------------

--- a/docs/usage/queues.rst
+++ b/docs/usage/queues.rst
@@ -4,7 +4,11 @@
 Queues and Members
 ==============================
 
-For more information, see the `Queue REST Resource <http://www.twilio.com/docs/api/rest/queue>`_ and `Member REST Resource <http://www.twilio.com/docs/api/rest/member>`_ documentation.
+For more information, see the
+`Queue REST Resource <http://www.twilio.com/docs/api/rest/queue>`_
+and `Member REST Resource <http://www.twilio.com/docs/api/rest/member>`_
+documentation.
+
 
 Listing Queues
 -----------------------
@@ -18,10 +22,11 @@ Listing Queues
     AUTH_TOKEN = "YYYYYYYYYYYYYYYYYY"
 
     client = TwilioRestClient(ACCOUNT_SID, AUTH_TOKEN)
-    conferences = client.queues.list()
+    queues = client.queues.list()
 
     for queue in queues:
         print queue.sid
+
 
 Listing Queue Members
 ----------------------
@@ -42,6 +47,7 @@ represents all current calls in the queue.
 
     for member in queue.queue_members.list():
         print member.call_sid
+
 
 Getting a specific Queue Member
 -------------------------------
@@ -97,3 +103,4 @@ default values are 'Front' and 'GET'
 
     # Dequeue the first call in the queue
     print members.dequeue('http://www.twilio.com/welcome/call')
+

--- a/docs/usage/recordings.rst
+++ b/docs/usage/recordings.rst
@@ -4,12 +4,17 @@
 Recordings
 ================
 
-For more information, see the `Recordings REST Resource <http://www.twilio.com/docs/api/rest/recording>`_ documentation.
+For more information, see the
+`Recordings REST Resource <http://www.twilio.com/docs/api/rest/recording>`_
+documentation.
+
 
 Audio Formats
 -----------------
 
-Each :class:`Recording` has a :attr:`formats` dictionary which lists the audio formats available for each recording. Below is an example :attr:`formats` dictionary.
+Each :class:`Recording` has a :attr:`formats` dictionary which lists the audio
+formats available for each recording.
+Below is an example :attr:`formats` dictionary.
 
 .. code-block:: python
 
@@ -18,10 +23,12 @@ Each :class:`Recording` has a :attr:`formats` dictionary which lists the audio f
        "wav": "http://www.dailywav.com/0112/noFateButWhatWeMake.wav",
    }
 
+
 Listing Your Recordings
 ----------------------------
 
-The following code will print out the :attr:`duration` for each :class:`Recording`.
+The following code will print out the :attr:`duration`
+for each :class:`Recording`.
 
 .. code-block:: python
 
@@ -35,7 +42,8 @@ The following code will print out the :attr:`duration` for each :class:`Recordin
     for recording in client.recordings.list():
         print recording.duration
 
-You can filter recordings by CallSid by passing the Sid as :attr:`call`. Filter recordings using :attr:`before` and :attr:`after` dates.
+You can filter recordings by CallSid by passing the Sid as :attr:`call`.
+Filter recordings using :attr:`before` and :attr:`after` dates.
 
 The following will only show recordings made before January 1, 2011.
 
@@ -51,6 +59,7 @@ The following will only show recordings made before January 1, 2011.
     client = TwilioRestClient(ACCOUNT_SID, AUTH_TOKEN)
     for recording in client.recordings.list(before=date(2011,1,1)):
         print recording.duration
+
 
 Deleting Recordings
 ---------------------
@@ -68,10 +77,11 @@ The :class:`Recordings` resource allows you to delete unnecessary recordings.
     client = TwilioRestClient(ACCOUNT_SID, AUTH_TOKEN)
     client.recordings.delete("RC123")
 
+
 Accessing Related Transcptions
 -------------------------------
 
-The :class:`Recordings` resource allows you to delete unnecessary recordings.
+The :class:`Recordings` allows you to retrieve associated transcriptions.
 The following prints out the text for each of the transcriptions associated
 with this recording.
 

--- a/docs/usage/token-generation.rst
+++ b/docs/usage/token-generation.rst
@@ -5,8 +5,9 @@ Generate Capability Tokens
 ===========================
 
 `Twilio Client <http://www.twilio.com/api/client>`_ allows you to make and
-receive connections in the browser. You can place a call to a phone on the PSTN
-network, all without leaving your browser. See the `Twilio Client Quickstart
+receive connections in the browser.
+You can place a call to a phone on the PSTN network,
+all without leaving your browser. See the `Twilio Client Quickstart
 <http:/www.twilio.com/docs/quickstart/client>`_ to get up and running with
 Twilio Client.
 
@@ -33,7 +34,11 @@ tokens. You'll need your Twilio AccountSid and AuthToken.
 Allow Incoming Connections
 ==============================
 
-Before a device running `Twilio Client <http://www.twilio.com/api/client>`_ can recieve incoming connections, the instance must first register a name (such as "Alice" or "Bob"). The :meth:`allow_client_incoming` method adds the client name to the capability token.
+Before a device running `Twilio Client <http://www.twilio.com/api/client>`_
+can recieve incoming connections, the instance must first register a name
+(such as "Alice" or "Bob").
+The :meth:`allow_client_incoming` method adds the client name to the
+capability token.
 
 .. code-block:: python
 
@@ -43,12 +48,19 @@ Before a device running `Twilio Client <http://www.twilio.com/api/client>`_ can 
 Allow Outgoing Connections
 ==============================
 
-To make an outgoing connection from a `Twilio Client <http://www.twilio.com/api/client>`_ device, you'll need to choose a `Twilio Application <http://www.twilio.com/docs/api/rest/applications>`_ to handle TwiML URLs. A Twilio Application is a collection of URLs responsible for outputting valid TwiML to control phone calls and SMS.
+To make an outgoing connection from a
+`Twilio Client <http://www.twilio.com/api/client>`_ device,
+you'll need to choose a
+`Twilio Application <http://www.twilio.com/docs/api/rest/applications>`_
+to handle TwiML URLs. A Twilio Application is a collection of URLs responsible
+for outputting valid TwiML to control phone calls and SMS.
 
 .. code-block:: python
 
-    application_sid = "APabe7650f654fc34655fc81ae71caa3ff" # Twilio Application Sid
+    # Twilio Application Sid
+    application_sid = "APabe7650f654fc34655fc81ae71caa3ff"
     capability.allow_client_outgoing(application_sid)
+
 
 Generate a Token
 ==================
@@ -66,3 +78,4 @@ token expiration, :meth:`generate` takes an optional :attr:`expires` argument.
 
 This token will now expire in 10 minutes. If you haven't guessed already,
 :attr:`expires` is expressed in seconds.
+

--- a/docs/usage/transcriptions.rst
+++ b/docs/usage/transcriptions.rst
@@ -4,9 +4,13 @@
 Transcriptions
 ================
 
-Transcriptions are generated from recordings via the `TwiML <Record> verb <http://www.twilio.com/docs/api/twiml/record>`_. Using the API, you can only read your transcription records.
+Transcriptions are generated from recordings via the
+`TwiML <Record> verb <http://www.twilio.com/docs/api/twiml/record>`_.
+Using the API, you can only read your transcription records.
 
-For more information, see the `Transcriptions REST Resource <http://www.twilio.com/docs/api/rest/transcription>`_ documentation.
+For more information, see the `Transcriptions REST Resource
+<http://www.twilio.com/docs/api/rest/transcription>`_ documentation.
+
 
 Listing Your Transcriptions
 ----------------------------
@@ -24,3 +28,4 @@ The following code will print out the length of each :class:`Transcription`.
     client = TwilioRestClient(ACCOUNT_SID, AUTH_TOKEN)
     for transcription in client.transcriptions.list():
         print transcription.duration
+

--- a/docs/usage/twiml.rst
+++ b/docs/usage/twiml.rst
@@ -6,7 +6,12 @@
 TwiML Creation
 ==============
 
-TwiML creation begins with the :class:`Response` verb. Each successive verb is created by calling various methods on the response, such as :meth:`say` or :meth:`play`. These methods return the verbs they create to ease the creation of nested TwiML. To finish, call the :meth:`toxml` method on the :class:`Response`, which returns raw TwiML.
+TwiML creation begins with the :class:`Response` verb.
+Each successive verb is created by calling various methods on the response,
+such as :meth:`say` or :meth:`play`.
+These methods return the verbs they create to ease creation of nested TwiML.
+To finish, call the :meth:`toxml` method on the :class:`Response`,
+which returns raw TwiML.
 
 .. code-block:: python
 
@@ -21,8 +26,9 @@ TwiML creation begins with the :class:`Response` verb. Each successive verb is c
    <?xml version="1.0" encoding="utf-8"?>
    <Response><Say>Hello</Say><Response>
 
-The verb methods (outlined in the :doc:`complete reference </api/twiml>`) take the body (only text)
-of the verb as the first argument. All attributes are keyword arguments.
+The verb methods (outlined in the :doc:`complete reference </api/twiml>`)
+take the body (only text) of the verb as the first argument.
+All attributes are keyword arguments.
 
 .. code-block:: python
 
@@ -35,9 +41,12 @@ of the verb as the first argument. All attributes are keyword arguments.
 .. code-block:: xml
 
     <?xml version="1.0" encoding="utf-8"?>
-    <Response><Play loop="3">https://api.twilio.com/cowbell.mp3</Play><Response>
+    <Response>
+        <Play loop="3">https://api.twilio.com/cowbell.mp3</Play>
+    <Response>
 
-Python 2.6+ added the :const:`with` statement for context management. Using :const:`with`, the module can *almost* emulate Ruby blocks.
+Python 2.6+ added the :const:`with` statement for context management.
+Using :const:`with`, the module can *almost* emulate Ruby blocks.
 
 .. code-block:: python
 
@@ -59,7 +68,8 @@ which returns the following
       <Gather finishOnKey="4"><Say>World</Say></Gather>
     </Response>
 
-If you don't want the XML declaration in your output, use the :meth:`toxml` method
+If you don't want the XML declaration in your output,
+use the :meth:`toxml` method
 
 .. code-block:: python
 
@@ -77,3 +87,4 @@ If you don't want the XML declaration in your output, use the :meth:`toxml` meth
       <Say>Hello</Say>
       <Gather finishOnKey="4"><Say>World</Say></Gather>
     </Response>
+

--- a/docs/usage/validation.rst
+++ b/docs/usage/validation.rst
@@ -52,6 +52,7 @@ actually from Twilio.
     else:
         print "NOT VALID.  It might have been spoofed!"
 
+
 Trailing Slashes
 ==================
 


### PR DESCRIPTION
Nothing really here, feel free to reject, I just love to read docs in my vim that are < 80 cols wide.

I found a couple of minor ~actual edits to make.

`queues` is undefined: https://github.com/twilio/twilio-python/blob/master/docs/usage/queues.rst#listing-queues

"The :class:`Recordings` resource allows you to delete unnecessary recordings" is erroneously repeated here: https://github.com/twilio/twilio-python/blob/master/docs/usage/recordings.rst#accessing-related-transcptions

There may be other small things to fish out in lieu of taking this whole commit. 
