### PR TITLE
add client.members() function to get queue members.

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -6,7 +6,10 @@ else:
 
 from twilio.rest import TwilioRestClient, resources
 from mock import patch, Mock
+from tools import create_mock_json
 
+
+AUTH = ("ACCOUNT_SID", "AUTH_TOKEN")
 
 class RestClientTest(unittest.TestCase):
 
@@ -18,7 +21,7 @@ class RestClientTest(unittest.TestCase):
         self.client.request("2010-04-01", method="GET")
         mock.assert_called_with("GET", "https://api.twilio.com/2010-04-01",
             headers={"User-Agent": 'twilio-python'}, params={},
-            auth=("ACCOUNT_SID", "AUTH_TOKEN"), data=None)
+            auth=AUTH, data=None)
 
     def test_connect_apps(self):
         self.assertIsInstance(self.client.connect_apps,
@@ -34,3 +37,11 @@ class RestClientTest(unittest.TestCase):
         mock.return_value.ok = True
         mock.return_value.content = '{"conferences": []}'
         self.client.conferences.list()
+
+    @patch("twilio.rest.resources.base.make_twilio_request")
+    def test_members(self, mock):
+        resp = create_mock_json("tests/resources/members_list.json")
+        mock.return_value = resp
+        self.client.members("QU123").list()
+        uri = "https://api.twilio.com/2010-04-01/Accounts/ACCOUNT_SID/Queues/QU123/Members"
+        mock.assert_called_with("GET", uri, params={}, auth=AUTH)

--- a/twilio/rest/__init__.py
+++ b/twilio/rest/__init__.py
@@ -8,6 +8,7 @@ from twilio.rest.resources import AuthorizedConnectApps
 from twilio.rest.resources import Calls
 from twilio.rest.resources import CallerIds
 from twilio.rest.resources import Queues
+from twilio.rest.resources import Members
 from twilio.rest.resources import ConnectApps
 from twilio.rest.resources import Notifications
 from twilio.rest.resources import Recordings
@@ -18,8 +19,6 @@ from twilio.rest.resources import PhoneNumbers
 from twilio.rest.resources import Conferences
 from twilio.rest.resources import Sandboxes
 from twilio.rest.resources import Usage
-from urllib import urlencode
-from urlparse import urljoin
 
 
 def find_credentials():
@@ -142,3 +141,11 @@ values from your Twilio Account at https://www.twilio.com/user/account.
         """
         base_uri = "%s/Conferences/%s" % (self.account_uri, conference_sid)
         return Participants(base_uri, self.auth)
+
+    def members(self, queue_sid):
+        """
+        Return a :class:`Members` instance for the :class:`Queue`
+        with the given queue_sid
+        """
+        base_uri = "%s/Queues/%s" % (self.account_uri, queue_sid)
+        return Members(base_uri, self.auth)


### PR DESCRIPTION
This does the same as the function for client.participants("conference_sid"), except for queue members.
