### PR TITLE
Make PhoneNumbers.update_instance consistent with PhoneNumber.update

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,3 +5,4 @@ simplejson
 unittest2
 coverage
 nosexcover
+six

--- a/tests/test_phone_numbers.py
+++ b/tests/test_phone_numbers.py
@@ -21,6 +21,19 @@ class PhoneNumberTest(unittest.TestCase):
         self.uri = "/base"
         self.auth = ("AC123", "token")
 
+    def test_update_rename_status_callback_url(self):
+        mock = Mock()
+        mock.uri = "/base"
+        instance = PhoneNumber(mock, "SID")
+        instance.update(status_callback_url="http://www.example.com")
+        mock.update.assert_called_with("SID", status_callback="http://www.example.com")
+
+    def test_update_instance_rename_status_callback_url(self):
+        resource = PhoneNumbers(self.uri, self.auth)
+        resource.update_instance = Mock()
+        resource.update("SID", status_callback_url="http://www.example.com")
+        resource.update_instance.assert_called_with("SID", {"status_callback": "http://www.example.com"})
+
     def test_application_sid(self):
         resource = PhoneNumbers(self.uri, self.auth)
         resource.update_instance = Mock()

--- a/twilio/rest/resources/phone_numbers.py
+++ b/twilio/rest/resources/phone_numbers.py
@@ -1,7 +1,7 @@
 import re
 
 from twilio import TwilioException
-from twilio.rest.resources.util import transform_params
+from twilio.rest.resources.util import change_dict_key, transform_params
 from twilio.rest.resources import InstanceResource, ListResource
 
 
@@ -79,14 +79,14 @@ class PhoneNumber(InstanceResource):
         a = self.parent.transfer(self.name, account_sid)
         self.load(a.__dict__)
 
-    def update(self, status_callback_url=None, **kwargs):
+    def update(self, **kwargs):
         """
         Update this phone number instance.
         """
-        kwargs["StatusCallback"] = kwargs.get("status_callback",
-                                              status_callback_url)
+        kwargs_copy = dict(kwargs)
+        change_dict_key(kwargs_copy, from_key="status_callback_url", to_key="status_callback")
 
-        a = self.parent.update(self.name, **kwargs)
+        a = self.parent.update(self.name, **kwargs_copy)
         self.load(a.__dict__)
 
     def delete(self):
@@ -170,9 +170,12 @@ class PhoneNumbers(ListResource):
         """
         Update this phone number instance
         """
-        if "application_sid" in kwargs:
+        kwargs_copy = dict(kwargs)
+        change_dict_key(kwargs_copy, from_key="status_callback_url", to_key="status_callback")
+
+        if "application_sid" in kwargs_copy:
             for sid_type in ["voice_application_sid", "sms_application_sid"]:
-                if sid_type not in kwargs:
-                    kwargs[sid_type] = kwargs["application_sid"]
-            del kwargs["application_sid"]
-        return self.update_instance(sid, kwargs)
+                if sid_type not in kwargs_copy:
+                    kwargs_copy[sid_type] = kwargs_copy["application_sid"]
+            del kwargs_copy["application_sid"]
+        return self.update_instance(sid, kwargs_copy)

--- a/twilio/rest/resources/util.py
+++ b/twilio/rest/resources/util.py
@@ -90,3 +90,17 @@ def normalize_dates(myfunc):
     inner_func.__doc__ = myfunc.__doc__
     inner_func.__repr__ = myfunc.__repr__
     return inner_func
+
+def change_dict_key(d, from_key, to_key):
+    """
+    Changes a dictionary's key from from_key to to_key. No-op if the key does not exist.
+
+    :param d: Dictionary with key to change
+    :param from_key: Old key
+    :param to_key: New key
+    :return: None
+    """
+    try:
+        d[to_key] = d.pop(from_key)
+    except KeyError:
+        pass


### PR DESCRIPTION
A recent change to PhoneNumber.update allowed passing "status_callback"
as "status_callback_url" for convenience. This change adds this
conveniece for PhoneNumbers.update_instance for consistency. Also,
kwargs is now copied to avoid side effects and status_callback_url is now
removed from kwargs as it is only relevant to update and
update_instance.
