### PR TITLE
Documentation fix

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -4,7 +4,8 @@
 
 From the root directory of this repository:
 
-    $ pip install -r requirements.txt 
+    $ python setup.py develop
+    $ pip install -r tests/requirements.txt 
 
 ## Running the tests
 


### PR DESCRIPTION
I found that following the docs as-is didn't let me run the tests. I tested this doc fix by running the commands and verifying that no step failed.

The only question I have is whether you want to include the `python setup.py develop` step as-is. Running the tests won't work without that or `python setup.py install` and I opted for `develop` because the documentation is in the testing section. But it's up to you.
