### PR TITLE
Simple fix to handle TypeError

### DIFF
--- a/twilio/rest/resources/base.py
+++ b/twilio/rest/resources/base.py
@@ -125,7 +125,7 @@ class Resource(object):
         if method == "DELETE":
             return resp, {}
         else:
-            return resp, json.loads(resp.content)
+            return resp, json.loads(resp.content.decode('utf-8'))
 
     @property
     def uri(self):


### PR DESCRIPTION
This commit fixes the error in this stack trace:

File "/.virtualenvs/rimidi/lib/python3.2/site-packages/twilio/rest/resources/base.py", line 225, in create_instance
    data=transform_params(body))
  File "/.virtualenvs/rimidi/lib/python3.2/site-packages/twilio/rest/resources/base.py", line 128, in request
    return resp, json.loads(resp.content)
  File "/Library/Frameworks/Python.framework/Versions/3.2/lib/python3.2/json/**init**.py", line 309, in loads
    return _default_decoder.decode(s)
  File "/Library/Frameworks/Python.framework/Versions/3.2/lib/python3.2/json/decoder.py", line 351, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
TypeError: can't use a string pattern on a bytes-like object
