### PR TITLE
Fixing 'data should be either a binary or a string'

### DIFF
--- a/twilio/rest/resources/base.py
+++ b/twilio/rest/resources/base.py
@@ -45,7 +45,7 @@ def make_request(method, url, params=None, data=None, headers=None,
             elif isinstance(v, string_types):
                 udata[key] = v.encode('utf-8')
             else:
-                raise ValueError('data should be a integer or binary or string')
+                raise ValueError('data should be iinteger or binary or string')
         data = urlencode(udata)
 
     if params is not None:


### PR DESCRIPTION
Sometimes an integer is passed i.e. timeout=30.
Also, text_type won't catch something like to='client:1' etc..
Added check for integer and changed check for string from text_type to string_types
