### PR TITLE
Fix the timing attack in RequestValidator

### DIFF
--- a/twilio/compat/__init__.py
+++ b/twilio/compat/__init__.py
@@ -11,3 +11,10 @@ except ImportError:
     from urllib import urlencode
     #noinspection PyUnresolvedReferences
     from urlparse import urlparse, urljoin
+
+try:
+    # python 2
+    from itertools import izip
+except ImportError:
+    # python 3
+    izip = zip

--- a/twilio/util.py
+++ b/twilio/util.py
@@ -1,11 +1,10 @@
 import base64
 import hmac
-import itertools
 import time
 from hashlib import sha1
 
 from twilio import jwt
-from twilio.compat import urlencode
+from twilio.compat import izip, urlencode
 from six import iteritems
 
 
@@ -58,7 +57,7 @@ def secure_compare(string1, string2):
     if len(string1) != len(string2):
         return False
     result = True
-    for c1, c2 in itertools.izip(string1, string2):
+    for c1, c2 in izip(string1, string2):
         result &= c1 == c2
     return result
 


### PR DESCRIPTION
`twilio.util.RequestValidator` uses naïve string comparison (the `==` operator) to check signatures, an operation which is designed to return a value as quickly as possible. Unfortunately this means the signature check will take a variable amount of time based on how much of the submitted signature is correct. Attackers can use this timing information to determine the correct signature for a fabricated request in `O(n)` time, instead of `O(256^n)` (where `n` is the number of bytes in the signature).

This patch changes `RequestValidator` to use a secure string comparison function, which will always take a constant amount of time when comparing two strings of the same length, and thus not leak information.
