### PR TITLE
Implementation of proxy functionality.

### DIFF
--- a/twilio/rest/resources/connection.py
+++ b/twilio/rest/resources/connection.py
@@ -1,5 +1,6 @@
 from twilio.rest.resources.imports import httplib2
 
+
 class Connection(object):
     _proxy_info = None
 
@@ -9,4 +10,5 @@ class Connection(object):
 
     @classmethod
     def set_proxy_info(cls, proxy_url, proxy_port):
-        cls._proxy_info = httplib2.ProxyInfo(httplib2.socks.PROXY_TYPE_HTTP, proxy_url, proxy_port)
+        cls._proxy_info = httplib2.ProxyInfo(httplib2.socks.PROXY_TYPE_HTTP,
+                                             proxy_url, proxy_port)


### PR DESCRIPTION
I'm in need of proxy functionality in the Twilio Python client for a project I'm working on. Setting a default proxy is not an option as not all connections the application is making can go through the proxy.

Here's a suggestion for an implementation, if you would prefer it being done differently let me know and I'd be happy to code it up some other way.

Thanks,
gustafa
