### PR TITLE
Position-less argument specifiers were not added until python 2.7. 

### DIFF
--- a/twilio/rest/resources/base.py
+++ b/twilio/rest/resources/base.py
@@ -202,7 +202,7 @@ class InstanceResource(Resource):
         return self.parent.delete(self.name)
 
     def __str__(self):
-        return "<{} {}>".format(self.__class__.__name__, self.name[0:5])
+        return "<{0} {1}>".format(self.__class__.__name__, self.name[0:5])
 
 
 class ListResource(Resource):
@@ -321,4 +321,4 @@ class ListResource(Resource):
         return instance
 
     def __str__(self):
-        return '<{} ({})>'.format(self.__class__.__name__, self.count())
+        return '<{0} ({1})>'.format(self.__class__.__name__, self.count())


### PR DESCRIPTION
Specify the position to fix support for older versions of python (2.5, 2.6).

> Changed in version 2.7: The positional argument specifiers can be omitted, so '{} {}' is equivalent to '{0} {1}'.

[source](http://docs.python.org/2/library/string.html#format-string-syntax)
