### PR TITLE
Remove unused dependency on Werkzeug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 #
 # You need to have the setuptools module installed. Try reading the setuptools
 # documentation: http://pypi.python.org/pypi/setuptools
-REQUIRES = ["httplib2 >= 0.7", "six", "Werkzeug"]
+REQUIRES = ["httplib2 >= 0.7", "six"]
 
 if sys.version_info < (2, 6):
     REQUIRES.append('simplejson')


### PR DESCRIPTION
Werkzeug isn't referenced in any of the modules, so it would be nice not to have to install it.
