### PR TITLE
more helpful error message

### DIFF
--- a/twilio/__init__.py
+++ b/twilio/__init__.py
@@ -32,6 +32,7 @@ class TwilioRestException(TwilioException):
                     self.status, self.msg, str(self.code), self.uri
                 )
         else:
-            error_message = "HTTP ERROR %s: %s \n %s" % (self.status, self.msg, self.uri)
+            error_message = "HTTP ERROR %s: %s \n %s" % (self.status,
+                                                         self.msg, self.uri)
 
         return error_message


### PR DESCRIPTION
Fixes #74 and #85 by adding a link to the docs for error messages that contain a Twilio error code.

Example error looks like this

``` bash
>>> message = client.messages.create(to="9191234567", from_="9191234567", body="")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "twilio/rest/resources/messages.py", line 112, in create
    return self.create_instance(kwargs)
  File "twilio/rest/resources/base.py", line 319, in create_instance
    data=transform_params(body))
  File "twilio/rest/resources/base.py", line 171, in request
    resp = make_twilio_request(method, uri, auth=self.auth, **kwargs)
  File "twilio/rest/resources/base.py", line 138, in make_twilio_request
    raise TwilioRestException(resp.status_code, resp.url, message, code)
twilio.TwilioRestException: HTTP ERROR 400: 21602: Message body is required.

    Please see: https://api.twilio.com/docs/errors/21602 for more information.

Requested URI: https://api.twilio.com/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Messages.json
```
