### PR TITLE
Allow you to update/delete instances

### DIFF
--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -1,7 +1,8 @@
 import unittest
 
-from mock import Mock
-from twilio.rest.resources import Applications
+from mock import Mock, patch
+
+from twilio.rest.resources import Applications, Application
 
 
 class ApplicationsTest(unittest.TestCase):
@@ -9,23 +10,23 @@ class ApplicationsTest(unittest.TestCase):
         self.parent = Mock()
         self.resource = Applications("http://api.twilio.com", ("user", "pass"))
 
-    def test_create_appliation_sms_url_method(self):
+    def test_create_application_sms_url_method(self):
         self.resource.create_instance = Mock()
         self.resource.create(sms_method="hey")
         self.resource.create_instance.assert_called_with({"sms_method": "hey"})
 
-    def test_create_appliation_sms_url(self):
+    def test_create_application_sms_url(self):
         self.resource.create_instance = Mock()
         self.resource.create(sms_url="hey")
         self.resource.create_instance.assert_called_with({"sms_url": "hey"})
 
-    def test_update_appliation_sms_url_method(self):
+    def test_update_application_sms_url_method(self):
         self.resource.update_instance = Mock()
         self.resource.update("123", sms_method="hey")
         self.resource.update_instance.assert_called_with(
             "123", {"sms_method": "hey"})
 
-    def test_update_appliation_sms_url(self):
+    def test_update_application_sms_url(self):
         self.resource.update_instance = Mock()
         self.resource.update("123", sms_url="hey")
         self.resource.update_instance.assert_called_with(
@@ -52,3 +53,16 @@ class ApplicationsTest(unittest.TestCase):
 
         uri = "http://api.twilio.com/Applications"
         request.assert_called_with("POST", uri, data={"FriendlyName": "hey"})
+
+    @patch("twilio.rest.resources.base.Resource.request")
+    def test_delete(self, req):
+        """ Deleting an application should work """
+        resp = Mock()
+        resp.content = ""
+        resp.status_code = 204
+        req.return_value = resp, {}
+
+        app = Application(self.resource, "AP123")
+        app.delete()
+        uri = "http://api.twilio.com/Applications/AP123"
+        req.assert_called_with("DELETE", uri)

--- a/tests/test_transcriptions.py
+++ b/tests/test_transcriptions.py
@@ -1,6 +1,6 @@
-from mock import patch
+from mock import patch, Mock
 from nose.tools import raises
-from twilio.rest.resources import Transcriptions
+from twilio.rest.resources import Transcriptions, Transcription
 from tools import create_mock_json
 
 BASE_URI = "https://api.twilio.com/2010-04-01/Accounts/AC123"
@@ -30,6 +30,20 @@ def test_get(mock):
     transcriptions.get("TR123")
 
     mock.assert_called_with("GET", uri, auth=AUTH)
+
+
+@patch("twilio.rest.resources.base.Resource.request")
+def test_delete_transcription(req):
+    """ Deleting a transcription should work """
+    resp = Mock()
+    resp.content = ""
+    resp.status_code = 204
+    req.return_value = resp, {}
+
+    app = Transcription(transcriptions, "TR123")
+    app.delete()
+    uri = "https://api.twilio.com/2010-04-01/Accounts/AC123/Transcriptions/TR123"
+    req.assert_called_with("DELETE", uri)
 
 
 @raises(AttributeError)

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -1,7 +1,9 @@
-from mock import patch
+from mock import patch, Mock
 from nose.tools import raises
+
 from tools import create_mock_json
 from twilio.rest.resources import Usage
+from twilio.rest.resources.usage import UsageTriggers, UsageTrigger
 
 BASE_URI = "https://api.twilio.com/2010-04-01/Accounts/AC123"
 ACCOUNT_SID = "AC123"
@@ -72,6 +74,20 @@ def test_records_paging(request):
         "EndDate": "2012-10-13",
         "Category": "sms"
     }, auth=AUTH)
+
+
+@patch("twilio.rest.resources.base.Resource.request")
+def test_delete_trigger(req):
+    resp = Mock()
+    resp.content = ""
+    resp.status_code = 204
+    req.return_value = resp, {}
+
+    triggers = UsageTriggers("https://api.twilio.com", None)
+    trigger = UsageTrigger(triggers, "UT123")
+    trigger.delete()
+    uri = "https://api.twilio.com/Usage/Triggers/UT123"
+    req.assert_called_with("DELETE", uri)
 
 
 @raises(AttributeError)

--- a/twilio/rest/resources/applications.py
+++ b/twilio/rest/resources/applications.py
@@ -8,13 +8,13 @@ class Application(InstanceResource):
         """
         Update this application
         """
-        return self.parent.update(self.sid, **kwargs)
+        return self.parent.update(self.name, **kwargs)
 
     def delete(self):
         """
         Delete this application
         """
-        return self.parent.delete(self.sid)
+        return self.parent.delete(self.name)
 
 
 class Applications(ListResource):

--- a/twilio/rest/resources/base.py
+++ b/twilio/rest/resources/base.py
@@ -29,6 +29,9 @@ class Response(object):
 
 def get_cert_file():
     """ Get the cert file location or bail """
+    # XXX - this currently fails test coverage because we don't actually go
+    # over the network anywhere. Might be good to have a test that stands up a
+    # local server and authenticates against it.
     try:
         # Apparently __file__ is not available in all places so wrapping this
         # in a try/catch

--- a/twilio/rest/resources/transcriptions.py
+++ b/twilio/rest/resources/transcriptions.py
@@ -7,7 +7,7 @@ class Transcription(InstanceResource):
         """
         Delete this transcription
         """
-        return self.parent.delete(self.sid)
+        return self.parent.delete(self.name)
 
 
 class Transcriptions(ListResource):

--- a/twilio/rest/resources/usage.py
+++ b/twilio/rest/resources/usage.py
@@ -9,13 +9,13 @@ class UsageTrigger(InstanceResource):
         """
         Update this usage trigger
         """
-        return self.parent.update(self.sid, **kwargs)
+        return self.parent.update(self.name, **kwargs)
 
     def delete(self):
         """
         Delete this usage trigger
         """
-        return self.parent.delete(self.sid)
+        return self.parent.delete(self.name)
 
 
 class UsageTriggers(ListResource):


### PR DESCRIPTION
Previously, we referenced the property `self.sid` which doesn't exist. Found coincidentally enough while checking --with-cover to see what parts of the library were actually exercised by tests, which is at least one nice thing to say about code coverage measures.
