### PR TITLE
Restore Python 2.5 compatibility by importing with_statement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+from __future__ import with_statement
 import sys
 from setuptools import setup, find_packages
 

--- a/tests/test_phone_numbers.py
+++ b/tests/test_phone_numbers.py
@@ -1,3 +1,4 @@
+from __future__ import with_statement
 import json
 import unittest
 

--- a/tests/test_rest.py.inactive
+++ b/tests/test_rest.py.inactive
@@ -1,3 +1,4 @@
+from __future__ import with_statement
 import json
 import os
 import unittest

--- a/tests/test_twiml.py
+++ b/tests/test_twiml.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import with_statement
 import unittest
 import xml.etree.ElementTree as ET
 


### PR DESCRIPTION
The `setup.py` script and some of the unit tests use `with` statements.
This breaks installation and unit tests on Python 2.5; Python 2.5
support is still advertised in the `classifiers`.
