### PR TITLE
Fix exception import errors and backwards compatibility.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ develop-eggs
 .installed.cfg
 scratch
 env
-venv
+venv*
 
 # Installer logs
 pip-log.txt

--- a/twilio/__init__.py
+++ b/twilio/__init__.py
@@ -6,6 +6,6 @@ from six import u
 # Backwards compatibility.
 from .version import __version__, __version_info__
 
-from exceptions import TwilioException, TwimlException
+from .exceptions import TwilioException, TwimlException
 
-from rest.exceptions import TwilioRestException
+from .rest.exceptions import TwilioRestException


### PR DESCRIPTION
Add exceptions to **init**.py for backwards compatibility.

Fixes #179 

This allows you to import exceptions like so:

```
from twilio import TwilioException
```

and also through the full (recommended) path:

```
from twilio.exceptions import TwilioException
```
