### PR TITLE
signature now returns native type for both python2 and python3

### DIFF
--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -2,19 +2,19 @@
 import unittest
 
 from nose.tools import assert_equal, assert_true
-from six import b
+from six import b, u
 
 from twilio.util import RequestValidator
 
 
 class ValidationTest(unittest.TestCase):
 
-    def test_validation(self):
+    def setUp(self):
         token = "1c892n40nd03kdnc0112slzkl3091j20"
-        validator = RequestValidator(token)
+        self.validator = RequestValidator(token)
 
-        uri = "http://www.postbin.org/1ed898x"
-        params = {
+        self.uri = "http://www.postbin.org/1ed898x"
+        self.params = {
             "AccountSid": "AC9a9f9392lad99kla0sklakjs90j092j3",
             "ApiVersion": "2010-04-01",
             "CallSid": "CAd800bb12c0426a7ea4230e492fef2a4f",
@@ -43,7 +43,20 @@ class ValidationTest(unittest.TestCase):
             "ToZip": "94612",
             }
 
+    def test_compute_signature_bytecode(self):
         expected = b("fF+xx6dTinOaCdZ0aIeNkHr/ZAA=")
+        signature = self.validator.compute_signature(self.uri,
+                                                     self.params,
+                                                     utf=False)
+        assert_equal(signature, expected)
 
-        assert_equal(validator.compute_signature(uri, params), expected)
-        assert_true(validator.validate(uri, params, expected))
+    def test_compute_signature_unicode(self):
+        expected = u("fF+xx6dTinOaCdZ0aIeNkHr/ZAA=")
+        signature = self.validator.compute_signature(self.uri,
+                                                     self.params,
+                                                     utf=True)
+        assert_equal(signature, expected)
+
+    def test_validation(self):
+        expected = "fF+xx6dTinOaCdZ0aIeNkHr/ZAA="
+        assert_true(self.validator.validate(self.uri, self.params, expected))

--- a/twilio/util.py
+++ b/twilio/util.py
@@ -5,7 +5,7 @@ from hashlib import sha1
 
 from . import jwt
 from .compat import izip, urlencode
-from six import iteritems
+from six import iteritems, PY3
 
 
 class RequestValidator(object):
@@ -13,12 +13,13 @@ class RequestValidator(object):
     def __init__(self, token):
         self.token = token.encode("utf-8")
 
-    def compute_signature(self, uri, params):
+    def compute_signature(self, uri, params, utf=PY3):
         """Compute the signature for a given request
 
         :param uri: full URI that Twilio requested on your server
         :param params: post vars that Twilio sent with the request
         :param auth: tuple with (account_sid, token)
+        :param utf: whether return should be bytestring or unicode (python3)
 
         :returns: The computed signature
         """
@@ -30,6 +31,8 @@ class RequestValidator(object):
         # compute signature and compare signatures
         mac = hmac.new(self.token, s.encode("utf-8"), sha1)
         computed = base64.b64encode(mac.digest())
+        if utf:
+            computed = computed.decode('utf-8')
 
         return computed.strip()
 


### PR DESCRIPTION
I ran into a bug where the validator would always return false in python3. I noticed the `compute_signature` method uses `base64`, which returns a bytecode string. Python3 uses unicode strings as default instead, and the two always compare to false. This pull request should fix that.
### Summary of Changes
- Added extra parameter `utf` to `compute_signature`, which defaults to True in python3 and False in python2
- If `utf` is True then `computed` will be coerced to a unicode string
- Added tests to cover both versions.

All tests pass in both python2 and python3, returns the native stringtype for both in interactive prompt, happy to do other checks if needed.
