### PR TITLE
Remove unittest2py3k dependency from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ REQUIRES = ["httplib2 >= 0.7", "six"]
 if sys.version_info < (2, 6):
     REQUIRES.append('simplejson')
 if sys.version_info >= (3,0):
-    REQUIRES.append('unittest2py3k')
     REQUIRES.append('socksipy-branch')
 
 setup(


### PR DESCRIPTION
`unittest2py3k` is not required for `twilio` to function correctly and it can intefere with standard unittest functionality like `expectedFailure` and `skip`.

I discovered this when a test marked as an `expectedFailure` continued to be displayed as a standard failure.
