### PR TITLE
Switch from socksipy to pysocks for 3.4 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ REQUIRES = ["httplib2 >= 0.7", "six"]
 if sys.version_info < (2, 6):
     REQUIRES.append('simplejson')
 if sys.version_info >= (3,0):
-    REQUIRES.append('socksipy-branch')
+    REQUIRES.append('pysocks')
 
 setup(
     name = "twilio",


### PR DESCRIPTION
Fixes #194 (or at least it did on my local 3.4 test... we'll see what travis thinks)

@WestleyArgentum
