### PR TITLE
Fixes for python 2.6

### DIFF
--- a/docs/usage/usage.rst
+++ b/docs/usage/usage.rst
@@ -19,7 +19,7 @@ over the last day.
     
     todays_usage = client.usage.records.today
     for category in todays_usage:
-        print '{}: {}'.format(category.description, category.price)
+        print '{0}: {1}'.format(category.description, category.price)
 
 This will print out the amount spent for each usage category over the
 last day. To see all of the possible usage categories, as well as all of the 

--- a/tests/task_router/test_activities.py
+++ b/tests/task_router/test_activities.py
@@ -21,14 +21,14 @@ class ActivityTest(unittest.TestCase):
 
         activities = Activities(BASE_URI, AUTH)
         activity = activities.create("Test Activity", True)
-        self.assertIsNotNone(activity)
+        self.assertTrue(activity is not None)
         self.assertEqual(activity.date_created, datetime(2014, 5, 14, 10, 50, 2, tzinfo=pytz.utc))
         exp_params = {
             'FriendlyName': "Test Activity",
             'Available': "true"
         }
 
-        request.assert_called_with("POST", "{}/Activities".format(BASE_URI),
+        request.assert_called_with("POST", "{0}/Activities".format(BASE_URI),
                                    data=exp_params, auth=AUTH,
                                    use_json_extension=False)
 
@@ -39,7 +39,7 @@ class ActivityTest(unittest.TestCase):
         resp.status_code = 204
         request.return_value = resp
 
-        uri = "{}/Activities/{}".format(BASE_URI, ACTIVITY_SID)
+        uri = "{0}/Activities/{1}".format(BASE_URI, ACTIVITY_SID)
         list_resource = Activities(BASE_URI, AUTH)
         activity = Activity(list_resource, ACTIVITY_SID)
         activity.delete()
@@ -53,7 +53,7 @@ class ActivityTest(unittest.TestCase):
         resp.status_code = 204
         request.return_value = resp
 
-        uri = "{}/Activities/{}".format(BASE_URI, ACTIVITY_SID)
+        uri = "{0}/Activities/{1}".format(BASE_URI, ACTIVITY_SID)
         list_resource = Activities(BASE_URI, AUTH)
         list_resource.delete(ACTIVITY_SID)
         request.assert_called_with("DELETE", uri, auth=AUTH,
@@ -65,7 +65,7 @@ class ActivityTest(unittest.TestCase):
         resp.status_code = 200
         request.return_value = resp
 
-        uri = "{}/Activities/{}".format(BASE_URI, ACTIVITY_SID)
+        uri = "{0}/Activities/{1}".format(BASE_URI, ACTIVITY_SID)
         list_resource = Activities(BASE_URI, AUTH)
         list_resource.get(ACTIVITY_SID)
         request.assert_called_with("GET", uri, auth=AUTH,
@@ -77,7 +77,7 @@ class ActivityTest(unittest.TestCase):
         resp.status_code = 200
         request.return_value = resp
 
-        uri = "{}/Activities".format(BASE_URI)
+        uri = "{0}/Activities".format(BASE_URI)
         list_resource = Activities(BASE_URI, AUTH)
         list_resource.list()
         request.assert_called_with("GET", uri, params={}, auth=AUTH,
@@ -89,7 +89,7 @@ class ActivityTest(unittest.TestCase):
         resp.status_code = 201
         request.return_value = resp
 
-        uri = "{}/Activities/{}".format(BASE_URI, ACTIVITY_SID)
+        uri = "{0}/Activities/{1}".format(BASE_URI, ACTIVITY_SID)
         list_resource = Activities(BASE_URI, AUTH)
         activity = Activity(list_resource, ACTIVITY_SID)
         activity.update(friendly_name='Test Activity', available=True)
@@ -107,7 +107,7 @@ class ActivityTest(unittest.TestCase):
         resp.status_code = 201
         request.return_value = resp
 
-        uri = "{}/Activities/{}".format(BASE_URI, ACTIVITY_SID)
+        uri = "{0}/Activities/{1}".format(BASE_URI, ACTIVITY_SID)
         list_resource = Activities(BASE_URI, AUTH)
         list_resource.update(ACTIVITY_SID, friendly_name='Test Activity', available="true")
         exp_params = {

--- a/tests/task_router/test_capability.py
+++ b/tests/task_router/test_capability.py
@@ -20,7 +20,7 @@ class TaskRouterCapabilityTest(unittest.TestCase):
         token = self.cap.generate_token()
         decoded = jwt.decode(token, self.auth_token)
 
-        self.assertIsNotNone(decoded)
+        self.assertTrue(decoded is not None)
         del decoded['exp']
         del decoded['policies']
 
@@ -33,27 +33,27 @@ class TaskRouterCapabilityTest(unittest.TestCase):
             'version': 'v1',
             'friendly_name': self.worker_sid,
         }
-        self.assertDictEqual(expected, decoded)
+        self.assertEqual(expected, decoded)
 
     def test_generate_token_default_ttl(self):
         token = self.cap.generate_token()
         decoded = jwt.decode(token, self.auth_token)
 
-        self.assertIsNotNone(decoded)
+        self.assertTrue(decoded is not None)
         self.assertEqual(int(time.time()) + 3600, decoded['exp'])
 
     def test_generate_token_custom_ttl(self):
         token = self.cap.generate_token(10000)
         decoded = jwt.decode(token, self.auth_token)
 
-        self.assertIsNotNone(decoded)
+        self.assertTrue(decoded is not None)
         self.assertEqual(int(time.time()) + 10000, decoded['exp'])
 
     def test_defaults(self):
         token = self.cap.generate_token()
         decoded = jwt.decode(token, self.auth_token)
 
-        self.assertIsNotNone(decoded)
+        self.assertTrue(decoded is not None)
         websocket_url = (
             'https://event-bridge.twilio.com/v1/wschannels/%s/%s' %
             (self.account_sid, self.worker_sid)
@@ -89,7 +89,7 @@ class TaskRouterCapabilityTest(unittest.TestCase):
         token = self.cap.generate_token()
         decoded = jwt.decode(token, self.auth_token)
 
-        self.assertIsNotNone(decoded)
+        self.assertTrue(decoded is not None)
         url = 'https://taskrouter.twilio.com/v1/Workspaces/%s/Workers/%s' % (
             self.workspace_sid,
             self.worker_sid,
@@ -109,7 +109,7 @@ class TaskRouterCapabilityTest(unittest.TestCase):
         token = self.cap.generate_token()
         decoded = jwt.decode(token, self.auth_token)
 
-        self.assertIsNotNone(decoded)
+        self.assertTrue(decoded is not None)
         url = 'https://taskrouter.twilio.com/v1/Workspaces/%s/Workers/%s' % (
             self.workspace_sid,
             self.worker_sid,
@@ -130,7 +130,7 @@ class TaskRouterCapabilityTest(unittest.TestCase):
         token = self.cap.generate_token()
         decoded = jwt.decode(token, self.auth_token)
 
-        self.assertIsNotNone(decoded)
+        self.assertTrue(decoded is not None)
         url = 'https://taskrouter.twilio.com/v1/Workspaces/%s/Tasks/**' % (
             self.workspace_sid,
         )

--- a/tests/task_router/test_events.py
+++ b/tests/task_router/test_events.py
@@ -18,7 +18,7 @@ class EventTest(unittest.TestCase):
         resp.status_code = 200
         request.return_value = resp
 
-        uri = "{}/Events/{}".format(BASE_URI, EVENT_SID)
+        uri = "{0}/Events/{1}".format(BASE_URI, EVENT_SID)
         list_resource = Events(BASE_URI, AUTH)
         list_resource.get(EVENT_SID)
         request.assert_called_with("GET", uri, auth=AUTH,
@@ -30,7 +30,7 @@ class EventTest(unittest.TestCase):
         resp.status_code = 200
         request.return_value = resp
 
-        uri = "{}/Events".format(BASE_URI)
+        uri = "{0}/Events".format(BASE_URI)
         list_resource = Events(BASE_URI, AUTH)
         list_resource.list()
         request.assert_called_with("GET", uri, params={}, auth=AUTH,

--- a/tests/task_router/test_reservations.py
+++ b/tests/task_router/test_reservations.py
@@ -18,7 +18,7 @@ class TaskQueueTest(unittest.TestCase):
         resp.status_code = 200
         request.return_value = resp
 
-        uri = "{}/Reservations/{}".format(BASE_URI, RESERVATION_SID)
+        uri = "{0}/Reservations/{1}".format(BASE_URI, RESERVATION_SID)
         list_resource = Reservations(BASE_URI, AUTH)
         list_resource.get(RESERVATION_SID)
         request.assert_called_with("GET", uri, auth=AUTH,
@@ -30,7 +30,7 @@ class TaskQueueTest(unittest.TestCase):
         resp.status_code = 200
         request.return_value = resp
 
-        uri = "{}/Reservations".format(BASE_URI)
+        uri = "{0}/Reservations".format(BASE_URI)
         list_resource = Reservations(BASE_URI, AUTH)
         list_resource.list()
         request.assert_called_with("GET", uri, params={}, auth=AUTH,
@@ -42,7 +42,7 @@ class TaskQueueTest(unittest.TestCase):
         resp.status_code = 201
         request.return_value = resp
 
-        uri = "{}/Reservations/{}".format(BASE_URI, RESERVATION_SID)
+        uri = "{0}/Reservations/{1}".format(BASE_URI, RESERVATION_SID)
         list_resource = Reservations(BASE_URI, AUTH)
         workflow = Reservation(list_resource, RESERVATION_SID)
         workflow.update(worker_activity_sid='WAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', reservation_status='rejected')
@@ -60,7 +60,7 @@ class TaskQueueTest(unittest.TestCase):
         resp.status_code = 201
         request.return_value = resp
 
-        uri = "{}/Reservations/{}".format(BASE_URI, RESERVATION_SID)
+        uri = "{0}/Reservations/{1}".format(BASE_URI, RESERVATION_SID)
         list_resource = Reservations(BASE_URI, AUTH)
         list_resource.update(RESERVATION_SID, worker_activity_sid='WAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
                              reservation_status='rejected')

--- a/tests/task_router/test_statistics.py
+++ b/tests/task_router/test_statistics.py
@@ -23,7 +23,7 @@ def test_fetch_worker_statistics(request):
     worker.statistics.get()
     request.assert_called_with(
         'GET',
-        '{}/Workers/WK123/Statistics'.format(BASE_URI),
+        '{0}/Workers/WK123/Statistics'.format(BASE_URI),
         params={},
         auth=AUTH,
         timeout=TIMEOUT,
@@ -40,7 +40,7 @@ def test_fetch_workers_statistics(request):
     workers = Workers(BASE_URI, AUTH, TIMEOUT)
     workers.statistics.get()
     request.assert_called_with('GET',
-                               '{}/Workers/Statistics'.format(BASE_URI),
+                               '{0}/Workers/Statistics'.format(BASE_URI),
                                params={}, auth=AUTH, timeout=TIMEOUT,
                                use_json_extension=False)
 
@@ -56,7 +56,7 @@ def test_fetch_task_queue_statistics(request):
     tq.load_subresources()
     tq.statistics.get()
     request.assert_called_with('GET',
-                               '{}/TaskQueues/TQ123/Statistics'.format(BASE_URI),
+                               '{0}/TaskQueues/TQ123/Statistics'.format(BASE_URI),
                                params={}, auth=AUTH, timeout=30,
                                use_json_extension=False)
 
@@ -70,7 +70,7 @@ def test_fetch_task_queues_statistics(request):
     tqs = TaskQueues(BASE_URI, AUTH, 30)
     tqs.statistics.get()
     request.assert_called_with('GET',
-                               '{}/TaskQueues/Statistics'.format(BASE_URI),
+                               '{0}/TaskQueues/Statistics'.format(BASE_URI),
                                params={}, auth=AUTH, use_json_extension=False)
 
 
@@ -85,5 +85,5 @@ def test_fetch_task_workflow_statistics(request):
     workflow.load_subresources()
     workflow.statistics.get()
     request.assert_called_with('GET',
-                               '{}/Workflows/WF123/Statistics'.format(BASE_URI),
+                               '{0}/Workflows/WF123/Statistics'.format(BASE_URI),
                                params={}, auth=AUTH, use_json_extension=False)

--- a/tests/task_router/test_task_queues.py
+++ b/tests/task_router/test_task_queues.py
@@ -28,7 +28,7 @@ class TaskQueueTest(unittest.TestCase):
         }
 
         request.assert_called_with("POST",
-                                   "{}/TaskQueues".format(BASE_URI),
+                                   "{0}/TaskQueues".format(BASE_URI),
                                    data=exp_params, auth=AUTH, timeout=TIMEOUT,
                                    use_json_extension=False)
 
@@ -39,7 +39,7 @@ class TaskQueueTest(unittest.TestCase):
         resp.status_code = 204
         request.return_value = resp
 
-        uri = "{}/TaskQueues/{}".format(BASE_URI, TASK_QUEUE_SID)
+        uri = "{0}/TaskQueues/{1}".format(BASE_URI, TASK_QUEUE_SID)
         list_resource = TaskQueues(BASE_URI, AUTH, TIMEOUT)
         task_queue = TaskQueue(list_resource, TASK_QUEUE_SID)
         task_queue.delete()
@@ -53,7 +53,7 @@ class TaskQueueTest(unittest.TestCase):
         resp.status_code = 204
         request.return_value = resp
 
-        uri = "{}/TaskQueues/{}".format(BASE_URI, TASK_QUEUE_SID)
+        uri = "{0}/TaskQueues/{1}".format(BASE_URI, TASK_QUEUE_SID)
         list_resource = TaskQueues(BASE_URI, AUTH, TIMEOUT)
         list_resource.delete(TASK_QUEUE_SID)
         request.assert_called_with("DELETE", uri, auth=AUTH, timeout=TIMEOUT,
@@ -65,7 +65,7 @@ class TaskQueueTest(unittest.TestCase):
         resp.status_code = 200
         request.return_value = resp
 
-        uri = "{}/TaskQueues/{}".format(BASE_URI, TASK_QUEUE_SID)
+        uri = "{0}/TaskQueues/{1}".format(BASE_URI, TASK_QUEUE_SID)
         list_resource = TaskQueues(BASE_URI, AUTH, TIMEOUT)
         list_resource.get(TASK_QUEUE_SID)
         request.assert_called_with("GET", uri, auth=AUTH, timeout=TIMEOUT,
@@ -77,7 +77,7 @@ class TaskQueueTest(unittest.TestCase):
         resp.status_code = 200
         request.return_value = resp
 
-        uri = "{}/TaskQueues".format(BASE_URI)
+        uri = "{0}/TaskQueues".format(BASE_URI)
         list_resource = TaskQueues(BASE_URI, AUTH, TIMEOUT)
         list_resource.list()
         request.assert_called_with("GET", uri, params={}, auth=AUTH, timeout=TIMEOUT,
@@ -89,7 +89,7 @@ class TaskQueueTest(unittest.TestCase):
         resp.status_code = 201
         request.return_value = resp
 
-        uri = "{}/TaskQueues/{}".format(BASE_URI, TASK_QUEUE_SID)
+        uri = "{0}/TaskQueues/{1}".format(BASE_URI, TASK_QUEUE_SID)
         list_resource = TaskQueues(BASE_URI, AUTH, TIMEOUT)
         task_queue = TaskQueue(list_resource, TASK_QUEUE_SID)
         task_queue.update(friendly_name='Test TaskQueue', assignment_activity_sid='WAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
@@ -110,7 +110,7 @@ class TaskQueueTest(unittest.TestCase):
         resp.status_code = 201
         request.return_value = resp
 
-        uri = "{}/TaskQueues/{}".format(BASE_URI, TASK_QUEUE_SID)
+        uri = "{0}/TaskQueues/{1}".format(BASE_URI, TASK_QUEUE_SID)
         list_resource = TaskQueues(BASE_URI, AUTH, TIMEOUT)
         list_resource.update(TASK_QUEUE_SID, friendly_name='Test TaskQueue',
                              assignment_activity_sid='WAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',

--- a/tests/task_router/test_tasks.py
+++ b/tests/task_router/test_tasks.py
@@ -26,7 +26,7 @@ class TaskTest(unittest.TestCase):
             'Timeout': 60
         }
 
-        request.assert_called_with("POST", "{}/Tasks".format(BASE_URI),
+        request.assert_called_with("POST", "{0}/Tasks".format(BASE_URI),
                                    data=exp_params, auth=AUTH,
                                    use_json_extension=False)
 
@@ -37,7 +37,7 @@ class TaskTest(unittest.TestCase):
         resp.status_code = 204
         request.return_value = resp
 
-        uri = "{}/Tasks/{}".format(BASE_URI, TASK_SID)
+        uri = "{0}/Tasks/{1}".format(BASE_URI, TASK_SID)
         list_resource = Tasks(BASE_URI, AUTH)
         task = Task(list_resource, TASK_SID)
         task.delete()
@@ -51,7 +51,7 @@ class TaskTest(unittest.TestCase):
         resp.status_code = 204
         request.return_value = resp
 
-        uri = "{}/Tasks/{}".format(BASE_URI, TASK_SID)
+        uri = "{0}/Tasks/{1}".format(BASE_URI, TASK_SID)
         list_resource = Tasks(BASE_URI, AUTH)
         list_resource.delete(TASK_SID)
         request.assert_called_with("DELETE", uri, auth=AUTH,
@@ -63,7 +63,7 @@ class TaskTest(unittest.TestCase):
         resp.status_code = 200
         request.return_value = resp
 
-        uri = "{}/Tasks/{}".format(BASE_URI, TASK_SID)
+        uri = "{0}/Tasks/{1}".format(BASE_URI, TASK_SID)
         list_resource = Tasks(BASE_URI, AUTH)
         list_resource.get(TASK_SID)
         request.assert_called_with("GET", uri, auth=AUTH,
@@ -75,7 +75,7 @@ class TaskTest(unittest.TestCase):
         resp.status_code = 200
         request.return_value = resp
 
-        uri = "{}/Tasks".format(BASE_URI)
+        uri = "{0}/Tasks".format(BASE_URI)
         list_resource = Tasks(BASE_URI, AUTH)
         list_resource.list()
         request.assert_called_with("GET", uri, params={}, auth=AUTH,
@@ -87,7 +87,7 @@ class TaskTest(unittest.TestCase):
         resp.status_code = 201
         request.return_value = resp
 
-        uri = "{}/Tasks/{}".format(BASE_URI, TASK_SID)
+        uri = "{0}/Tasks/{1}".format(BASE_URI, TASK_SID)
         list_resource = Tasks(BASE_URI, AUTH)
         workflow = Task(list_resource, TASK_SID)
         workflow.update(attributes='attributes', workflow_sid='WFaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
@@ -105,7 +105,7 @@ class TaskTest(unittest.TestCase):
         resp.status_code = 201
         request.return_value = resp
 
-        uri = "{}/Tasks/{}".format(BASE_URI, TASK_SID)
+        uri = "{0}/Tasks/{1}".format(BASE_URI, TASK_SID)
         list_resource = Tasks(BASE_URI, AUTH)
         list_resource.update(TASK_SID, attributes='attributes', workflow_sid='WFaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
         exp_params = {

--- a/tests/task_router/test_workers.py
+++ b/tests/task_router/test_workers.py
@@ -25,7 +25,7 @@ class WorkerTest(unittest.TestCase):
             'FriendlyName': "Test Worker"
         }
 
-        request.assert_called_with("POST", "{}/Workers".format(BASE_URI), data=exp_params, auth=AUTH,
+        request.assert_called_with("POST", "{0}/Workers".format(BASE_URI), data=exp_params, auth=AUTH,
                                    timeout=TIMEOUT, use_json_extension=False)
 
     @patch('twilio.rest.resources.base.make_twilio_request')
@@ -35,7 +35,7 @@ class WorkerTest(unittest.TestCase):
         resp.status_code = 204
         request.return_value = resp
 
-        uri = "{}/Workers/{}".format(BASE_URI, WORKER_SID)
+        uri = "{0}/Workers/{1}".format(BASE_URI, WORKER_SID)
         list_resource = Workers(BASE_URI, AUTH, TIMEOUT)
         worker = Worker(list_resource, WORKER_SID)
         worker.delete()
@@ -49,7 +49,7 @@ class WorkerTest(unittest.TestCase):
         resp.status_code = 204
         request.return_value = resp
 
-        uri = "{}/Workers/{}".format(BASE_URI, WORKER_SID)
+        uri = "{0}/Workers/{1}".format(BASE_URI, WORKER_SID)
         list_resource = Workers(BASE_URI, AUTH, TIMEOUT)
         list_resource.delete(WORKER_SID)
         request.assert_called_with("DELETE", uri, auth=AUTH, timeout=TIMEOUT,
@@ -61,7 +61,7 @@ class WorkerTest(unittest.TestCase):
         resp.status_code = 200
         request.return_value = resp
 
-        uri = "{}/Workers/{}".format(BASE_URI, WORKER_SID)
+        uri = "{0}/Workers/{1}".format(BASE_URI, WORKER_SID)
         list_resource = Workers(BASE_URI, AUTH, TIMEOUT)
         list_resource.get(WORKER_SID)
         request.assert_called_with("GET", uri, auth=AUTH,
@@ -73,7 +73,7 @@ class WorkerTest(unittest.TestCase):
         resp.status_code = 200
         request.return_value = resp
 
-        uri = "{}/Workers".format(BASE_URI)
+        uri = "{0}/Workers".format(BASE_URI)
         list_resource = Workers(BASE_URI, AUTH, TIMEOUT)
         list_resource.list()
         request.assert_called_with("GET", uri, params={}, auth=AUTH,
@@ -85,7 +85,7 @@ class WorkerTest(unittest.TestCase):
         resp.status_code = 201
         request.return_value = resp
 
-        uri = "{}/Workers/{}".format(BASE_URI, WORKER_SID)
+        uri = "{0}/Workers/{1}".format(BASE_URI, WORKER_SID)
         list_resource = Workers(BASE_URI, AUTH, TIMEOUT)
         worker = Worker(list_resource, WORKER_SID)
         worker.update(friendly_name='Test Worker')
@@ -102,7 +102,7 @@ class WorkerTest(unittest.TestCase):
         resp.status_code = 201
         request.return_value = resp
 
-        uri = "{}/Workers/{}".format(BASE_URI, WORKER_SID)
+        uri = "{0}/Workers/{1}".format(BASE_URI, WORKER_SID)
         list_resource = Workers(BASE_URI, AUTH, TIMEOUT)
         list_resource.update(WORKER_SID, friendly_name='Test Worker')
         exp_params = {

--- a/tests/task_router/test_workflows.py
+++ b/tests/task_router/test_workflows.py
@@ -26,7 +26,7 @@ class WorkflowTest(unittest.TestCase):
             'AssignmentCallbackUrl': 'http://www.example.com'
         }
 
-        request.assert_called_with("POST", "{}/Workflows".format(BASE_URI), data=exp_params, auth=AUTH,
+        request.assert_called_with("POST", "{0}/Workflows".format(BASE_URI), data=exp_params, auth=AUTH,
                                    use_json_extension=False)
 
     @patch('twilio.rest.resources.base.make_twilio_request')
@@ -36,7 +36,7 @@ class WorkflowTest(unittest.TestCase):
         resp.status_code = 204
         request.return_value = resp
 
-        uri = "{}/Workflows/{}".format(BASE_URI, WORKFLOW_SID)
+        uri = "{0}/Workflows/{1}".format(BASE_URI, WORKFLOW_SID)
         list_resource = Workflows(BASE_URI, AUTH)
         workflow = Workflow(list_resource, WORKFLOW_SID)
         workflow.delete()
@@ -50,7 +50,7 @@ class WorkflowTest(unittest.TestCase):
         resp.status_code = 204
         request.return_value = resp
 
-        uri = "{}/Workflows/{}".format(BASE_URI, WORKFLOW_SID)
+        uri = "{0}/Workflows/{1}".format(BASE_URI, WORKFLOW_SID)
         list_resource = Workflows(BASE_URI, AUTH)
         list_resource.delete(WORKFLOW_SID)
         request.assert_called_with("DELETE", uri, auth=AUTH,
@@ -62,7 +62,7 @@ class WorkflowTest(unittest.TestCase):
         resp.status_code = 200
         request.return_value = resp
 
-        uri = "{}/Workflows/{}".format(BASE_URI, WORKFLOW_SID)
+        uri = "{0}/Workflows/{1}".format(BASE_URI, WORKFLOW_SID)
         list_resource = Workflows(BASE_URI, AUTH)
         list_resource.get(WORKFLOW_SID)
         request.assert_called_with("GET", uri, auth=AUTH,
@@ -74,7 +74,7 @@ class WorkflowTest(unittest.TestCase):
         resp.status_code = 200
         request.return_value = resp
 
-        uri = "{}/Workflows".format(BASE_URI)
+        uri = "{0}/Workflows".format(BASE_URI)
         list_resource = Workflows(BASE_URI, AUTH)
         list_resource.list()
         request.assert_called_with("GET", uri, params={}, auth=AUTH,
@@ -86,7 +86,7 @@ class WorkflowTest(unittest.TestCase):
         resp.status_code = 201
         request.return_value = resp
 
-        uri = "{}/Workflows/{}".format(BASE_URI, WORKFLOW_SID)
+        uri = "{0}/Workflows/{1}".format(BASE_URI, WORKFLOW_SID)
         list_resource = Workflows(BASE_URI, AUTH)
         workflow = Workflow(list_resource, WORKFLOW_SID)
         workflow.update(friendly_name='Test Workflow', configuration='configuration',
@@ -106,7 +106,7 @@ class WorkflowTest(unittest.TestCase):
         resp.status_code = 201
         request.return_value = resp
 
-        uri = "{}/Workflows/{}".format(BASE_URI, WORKFLOW_SID)
+        uri = "{0}/Workflows/{1}".format(BASE_URI, WORKFLOW_SID)
         list_resource = Workflows(BASE_URI, AUTH)
         list_resource.update(WORKFLOW_SID, friendly_name='Test Workflow', configuration='configuration',
                              assignment_callback_url='http://www.example.com')

--- a/tests/task_router/test_workspaces.py
+++ b/tests/task_router/test_workspaces.py
@@ -18,7 +18,7 @@ class WorkspaceTest(unittest.TestCase):
         resp.status_code = 201
         request.return_value = resp
 
-        uri = "{}/Workspaces".format(BASE_URI)
+        uri = "{0}/Workspaces".format(BASE_URI)
         list_resource = Workspaces(BASE_URI, AUTH)
         list_resource.create("Test Workspace", event_callback_uri="http://www.example.com", template='FIFO')
         exp_params = {
@@ -37,7 +37,7 @@ class WorkspaceTest(unittest.TestCase):
         resp.status_code = 204
         request.return_value = resp
 
-        uri = "{}/Workspaces/{}".format(BASE_URI, WORKSPACE_SID)
+        uri = "{0}/Workspaces/{1}".format(BASE_URI, WORKSPACE_SID)
         list_resource = Workspaces(BASE_URI, AUTH)
         workspace = Workspace(list_resource, WORKSPACE_SID)
         workspace.delete()
@@ -51,7 +51,7 @@ class WorkspaceTest(unittest.TestCase):
         resp.status_code = 204
         request.return_value = resp
 
-        uri = "{}/Workspaces/{}".format(BASE_URI, WORKSPACE_SID)
+        uri = "{0}/Workspaces/{1}".format(BASE_URI, WORKSPACE_SID)
         list_resource = Workspaces(BASE_URI, AUTH)
         list_resource.delete(WORKSPACE_SID)
         request.assert_called_with("DELETE", uri, auth=AUTH,
@@ -63,7 +63,7 @@ class WorkspaceTest(unittest.TestCase):
         resp.status_code = 200
         request.return_value = resp
 
-        uri = "{}/Workspaces/{}".format(BASE_URI, WORKSPACE_SID)
+        uri = "{0}/Workspaces/{1}".format(BASE_URI, WORKSPACE_SID)
         list_resource = Workspaces(BASE_URI, AUTH)
         list_resource.get(WORKSPACE_SID)
         request.assert_called_with("GET", uri, auth=AUTH,
@@ -75,7 +75,7 @@ class WorkspaceTest(unittest.TestCase):
         resp.status_code = 200
         request.return_value = resp
 
-        uri = "{}/Workspaces".format(BASE_URI)
+        uri = "{0}/Workspaces".format(BASE_URI)
         list_resource = Workspaces(BASE_URI, AUTH)
         list_resource.list()
         request.assert_called_with("GET", uri, params={}, auth=AUTH,
@@ -87,7 +87,7 @@ class WorkspaceTest(unittest.TestCase):
         resp.status_code = 201
         request.return_value = resp
 
-        uri = "{}/Workspaces/{}".format(BASE_URI, WORKSPACE_SID)
+        uri = "{0}/Workspaces/{1}".format(BASE_URI, WORKSPACE_SID)
         list_resource = Workspaces(BASE_URI, AUTH)
         workspace = Workspace(list_resource, WORKSPACE_SID)
         workspace.update(friendly_name='Test Workspace', event_callback_uri="http://www.example.com", template='FIFO')
@@ -106,7 +106,7 @@ class WorkspaceTest(unittest.TestCase):
         resp.status_code = 201
         request.return_value = resp
 
-        uri = "{}/Workspaces/{}".format(BASE_URI, WORKSPACE_SID)
+        uri = "{0}/Workspaces/{1}".format(BASE_URI, WORKSPACE_SID)
         list_resource = Workspaces(BASE_URI, AUTH)
         list_resource.update(WORKSPACE_SID, friendly_name='Test Workspace', event_callback_uri="http://www.example.com",
                              template='FIFO')

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,7 +1,7 @@
 import unittest
 
 from mock import patch, Mock, sentinel, ANY
-from nose.tools import assert_equal, assert_true, assert_is_not_none
+from nose.tools import assert_equal, assert_true
 
 from twilio.rest.resources.imports import json
 from twilio.rest import TwilioRestClient, resources, TwilioTaskRouterClient
@@ -56,7 +56,7 @@ class RestClientTest(unittest.TestCase):
         request.return_value = resp
         workflows = self.task_router_client.workflows("WS123")
         workflows = workflows.list()
-        assert_is_not_none(workflows[0].sid)
+        assert_true(workflows[0].sid is not None)
         uri = "https://taskrouter.twilio.com/v1/Workspaces/WS123/Workflows"
         request.assert_called_with("GET", uri, headers=ANY, params={}, auth=AUTH)
 

--- a/tests/test_rest.py.inactive
+++ b/tests/test_rest.py.inactive
@@ -344,7 +344,7 @@ class CallsTest(ListResourceTest):
 
     def test_paging(self):
         with open("tests/resources/calls_list.json") as f:
-            uri = "{}Calls.json?Page=2".format(ACCOUNT_URI)
+            uri = "{0}Calls.json?Page=2".format(ACCOUNT_URI)
             self.check_paging(self.c.calls, f.read(), uri)
 
     def test_uri(self):
@@ -453,7 +453,7 @@ class CallerIdsTest(ListResourceTest):
 
     def test_paging(self):
         with open("tests/resources/outgoing_caller_ids_list.json") as f:
-            uri = "{}OutgoingCallerIds.json?Page=2".format(ACCOUNT_URI)
+            uri = "{0}OutgoingCallerIds.json?Page=2".format(ACCOUNT_URI)
             self.check_paging(self.c.caller_ids, f.read(), uri)
 
     def test_validate(self):
@@ -479,7 +479,7 @@ class CallerIdsTest(ListResourceTest):
         body = urllib.urlencode({
                 "PhoneNumber": 5551231234,
                 })
-        e_uri = "{}OutgoingCallerIds.json?{}".format(ACCOUNT_URI,body)
+        e_uri = "{0}OutgoingCallerIds.json?{1}".format(ACCOUNT_URI,body)
         request = self.mock_request()
 
         with self.assertRaises(TwilioException) as cm:
@@ -489,17 +489,17 @@ class CallerIdsTest(ListResourceTest):
                                    headers=DEFAULT_HEADERS)
 
     def test_list_uri(self):
-        uri =  "{}OutgoingCallerIds.json".format(ACCOUNT_URI)
+        uri =  "{0}OutgoingCallerIds.json".format(ACCOUNT_URI)
         self.check_list_uri(self.c.caller_ids, uri)
 
     def test_delete_uri(self):
         sid = "CI123123"
-        uri = "{}OutgoingCallerIds/{}.json".format(ACCOUNT_URI, sid)
+        uri = "{0}OutgoingCallerIds/{1}.json".format(ACCOUNT_URI, sid)
         self.check_delete_uri(self.c.caller_ids, sid, uri)
 
     def test_update_uri(self):
         sid = "CI123123"
-        uri = "{}OutgoingCallerIds/{}.json".format(ACCOUNT_URI, sid)
+        uri = "{0}OutgoingCallerIds/{1}.json".format(ACCOUNT_URI, sid)
         body = urllib.urlencode({"FriendlyName": "MyCallerId"})
         self.check_update_uri(self.c.caller_ids, sid, uri, body,
                               friendly_name="MyCallerId")
@@ -526,20 +526,20 @@ class CallerIdTest(InstanceResourceTest):
 class NotificationsTest(ListResourceTest):
 
     def test_list_uri(self):
-        uri =  "{}Notifications.json".format(ACCOUNT_URI)
+        uri =  "{0}Notifications.json".format(ACCOUNT_URI)
         self.check_list_uri(self.c.notifications, uri)
 
     def test_list_uri_fiter(self):
         query = urllib.urlencode({"MessageDate<": "2009-10-10",
                                   "MessageDate>": "2010-10-10",
                                   "LogLevel": 1})
-        uri =  "{}Notifications.json?{}".format(ACCOUNT_URI, query)
+        uri =  "{0}Notifications.json?{1}".format(ACCOUNT_URI, query)
         self.check_list_uri(self.c.notifications, uri, before="2009-10-10",
                             after="2010-10-10", log_level=1)
 
     def test_delete_uri(self):
         sid = "N123123"
-        uri = "{}Notifications/{}.json".format(ACCOUNT_URI, sid)
+        uri = "{0}Notifications/{1}.json".format(ACCOUNT_URI, sid)
         self.check_delete_uri(self.c.notifications, sid, uri)
 
 class NotificationTest(InstanceResourceTest):
@@ -557,7 +557,7 @@ class NotificationTest(InstanceResourceTest):
 
     def test_paging(self):
         with open("tests/resources/notifications_list.json") as f:
-            uri =  "{}.json?Page=2".format(self.base_uri)
+            uri =  "{0}.json?Page=2".format(self.base_uri)
             request = self.mock_request(content=f.read())
             self.c.notifications.list(page=2)
             request.assert_called_with(uri, method="GET",
@@ -567,12 +567,12 @@ class NotificationTest(InstanceResourceTest):
 class TranscriptionsTest(ListResourceTest):
 
     def test_list_uri(self):
-        uri =  "{}Transcriptions.json".format(ACCOUNT_URI)
+        uri =  "{0}Transcriptions.json".format(ACCOUNT_URI)
         self.check_list_uri(self.c.transcriptions, uri)
 
     def test_paging(self):
         with open("tests/resources/transcriptions_list.json") as f:
-            uri =  "{}Transcriptions.json?Page=2".format(ACCOUNT_URI)
+            uri =  "{0}Transcriptions.json?Page=2".format(ACCOUNT_URI)
             request = self.mock_request(content=f.read())
             self.c.transcriptions.list(page=2)
             request.assert_called_with(uri, method="GET",
@@ -585,16 +585,16 @@ class PhoneNumbersTest(ListResourceTest):
 
     def test_paging(self):
         with open(self.list_response) as f:
-            uri = "{}IncomingPhoneNumbers.json?Page=2".format(ACCOUNT_URI)
+            uri = "{0}IncomingPhoneNumbers.json?Page=2".format(ACCOUNT_URI)
             self.check_paging(self.c.phone_numbers, f.read(), uri)
 
     def test_list_uri(self):
-        uri =  "{}IncomingPhoneNumbers.json".format(ACCOUNT_URI)
+        uri =  "{0}IncomingPhoneNumbers.json".format(ACCOUNT_URI)
         self.check_list_uri(self.c.phone_numbers, uri)
 
     def test_delete_uri(self):
         sid = "PN123123"
-        uri =  "{}IncomingPhoneNumbers/{}.json".format(ACCOUNT_URI, sid)
+        uri =  "{0}IncomingPhoneNumbers/{1}.json".format(ACCOUNT_URI, sid)
         self.check_delete_uri(self.c.phone_numbers, sid, uri)
 
     def test_check_count(self):
@@ -610,18 +610,18 @@ class ConferencesTest(ListResourceTest):
 
     def test_paging(self):
         with open(self.list_response) as f:
-            uri = "{}Conferences.json?Page=2".format(ACCOUNT_URI)
+            uri = "{0}Conferences.json?Page=2".format(ACCOUNT_URI)
             self.check_paging(self.c.conferences, f.read(), uri)
 
     def test_list_uri(self):
-        uri =  "{}Conferences.json".format(ACCOUNT_URI)
+        uri =  "{0}Conferences.json".format(ACCOUNT_URI)
         self.check_list_uri(self.c.conferences, uri)
 
 
 class AvailableNumbersTest(ListResourceTest):
 
     def test_search_local_uri(self):
-        uri =  "{}AvailablePhoneNumbers/US/Local.json".format(ACCOUNT_URI)
+        uri =  "{0}AvailablePhoneNumbers/US/Local.json".format(ACCOUNT_URI)
         body = '{"available_phone_numbers":[]}'
         request = self.mock_request(content=body)
         self.c.phone_numbers.search()
@@ -629,7 +629,7 @@ class AvailableNumbersTest(ListResourceTest):
                                    headers=DEFAULT_HEADERS)
 
     def test_search_local_uri(self):
-        uri =  "{}AvailablePhoneNumbers/US/TollFree.json".format(ACCOUNT_URI)
+        uri =  "{0}AvailablePhoneNumbers/US/TollFree.json".format(ACCOUNT_URI)
         body = '{"available_phone_numbers":[]}'
         request = self.mock_request(content=body)
         self.c.phone_numbers.search(type="TOLLFREE")
@@ -644,9 +644,9 @@ class RecordingsTest(ListResourceTest):
 
     def test_paging(self):
         with open(self.list_response) as f:
-            uri = "{}Recordings.json?Page=2".format(ACCOUNT_URI)
+            uri = "{0}Recordings.json?Page=2".format(ACCOUNT_URI)
             self.check_paging(self.c.recordings, f.read(), uri)
 
     def test_list_uri(self):
-        uri =  "{}Recordings.json".format(ACCOUNT_URI)
+        uri =  "{0}Recordings.json".format(ACCOUNT_URI)
         self.check_list_uri(self.c.recordings, uri)

--- a/twilio/rest/__init__.py
+++ b/twilio/rest/__init__.py
@@ -92,7 +92,8 @@ values from your Twilio Account at https://www.twilio.com/user/account.
         self.base = base
         self.auth = (account, token)
         self.timeout = timeout
-        self.account_uri = "{0}/{1}/Accounts/{2}".format(base, version, account)
+        self.account_uri = "{0}/{1}/Accounts/{2}".format(base,
+                                                         version, account)
 
     def dependent_phone_numbers(self, address_sid):
         """
@@ -282,8 +283,8 @@ class TwilioTaskRouterClient(TwilioClient):
         Return a :class:`Reservations` instance for the :class:`Reservation`
         with the given workspace_sid ans task_sid
         """
-        base_uri = "{0}/{1}/Tasks/{2}".format(self.workspace_uri, workspace_sid,
-                                           task_sid)
+        base_uri = "{0}/{1}/Tasks/{2}".format(self.workspace_uri,
+                                              workspace_sid, task_sid)
         return Reservations(base_uri, self.auth, self.timeout)
 
     def task_queues(self, workspace_sid):

--- a/twilio/rest/__init__.py
+++ b/twilio/rest/__init__.py
@@ -92,7 +92,7 @@ values from your Twilio Account at https://www.twilio.com/user/account.
         self.base = base
         self.auth = (account, token)
         self.timeout = timeout
-        self.account_uri = "{}/{}/Accounts/{}".format(base, version, account)
+        self.account_uri = "{0}/{1}/Accounts/{2}".format(base, version, account)
 
     def dependent_phone_numbers(self, address_sid):
         """
@@ -256,8 +256,8 @@ class TwilioTaskRouterClient(TwilioClient):
         """
         super(TwilioTaskRouterClient, self).__init__(account, token, base,
                                                      version, timeout)
-        self.base_uri = "{}/{}".format(base, version)
-        self.workspace_uri = "{}/Workspaces".format(self.base_uri)
+        self.base_uri = "{0}/{1}".format(base, version)
+        self.workspace_uri = "{0}/Workspaces".format(self.base_uri)
 
         self.workspaces = Workspaces(self.base_uri, self.auth, timeout)
 
@@ -266,7 +266,7 @@ class TwilioTaskRouterClient(TwilioClient):
         Return a :class:`Activities` instance for the :class:`Activity`
         with the given workspace_sid
         """
-        base_uri = "{}/{}".format(self.workspace_uri, workspace_sid)
+        base_uri = "{0}/{1}".format(self.workspace_uri, workspace_sid)
         return Activities(base_uri, self.auth, self.timeout)
 
     def events(self, workspace_sid):
@@ -274,7 +274,7 @@ class TwilioTaskRouterClient(TwilioClient):
         Return a :class:`Events` instance for the :class:`Event` with the given
         workspace_sid
         """
-        base_uri = "{}/{}".format(self.workspace_uri, workspace_sid)
+        base_uri = "{0}/{1}".format(self.workspace_uri, workspace_sid)
         return Events(base_uri, self.auth, self.timeout)
 
     def reservations(self, workspace_sid, task_sid):
@@ -282,7 +282,7 @@ class TwilioTaskRouterClient(TwilioClient):
         Return a :class:`Reservations` instance for the :class:`Reservation`
         with the given workspace_sid ans task_sid
         """
-        base_uri = "{}/{}/Tasks/{}".format(self.workspace_uri, workspace_sid,
+        base_uri = "{0}/{1}/Tasks/{2}".format(self.workspace_uri, workspace_sid,
                                            task_sid)
         return Reservations(base_uri, self.auth, self.timeout)
 
@@ -291,7 +291,7 @@ class TwilioTaskRouterClient(TwilioClient):
         Return a :class:`TaskQueues` instance for the :class:`TaskQueue` with
         the given workspace_sid
         """
-        base_uri = "{}/{}".format(self.workspace_uri, workspace_sid)
+        base_uri = "{0}/{1}".format(self.workspace_uri, workspace_sid)
         return TaskQueues(base_uri, self.auth, self.timeout)
 
     def tasks(self, workspace_sid):
@@ -299,7 +299,7 @@ class TwilioTaskRouterClient(TwilioClient):
         Return a :class:`Tasks` instance for the :class:`Task` with the given
         workspace_sid
         """
-        base_uri = "{}/{}".format(self.workspace_uri, workspace_sid)
+        base_uri = "{0}/{1}".format(self.workspace_uri, workspace_sid)
         return Tasks(base_uri, self.auth, self.timeout)
 
     def workers(self, workspace_sid):
@@ -307,7 +307,7 @@ class TwilioTaskRouterClient(TwilioClient):
         Return a :class:`Workers` instance for the :class:`Worker` with the
         given workspace_sid
         """
-        base_uri = "{}/{}".format(self.workspace_uri, workspace_sid)
+        base_uri = "{0}/{1}".format(self.workspace_uri, workspace_sid)
         return Workers(base_uri, self.auth, self.timeout)
 
     def workflows(self, workspace_sid):
@@ -315,5 +315,5 @@ class TwilioTaskRouterClient(TwilioClient):
         Return a :class:`Workflows` instance for the :class:`Workflow` with the
         given workspace_sid
         """
-        base_uri = "{}/{}".format(self.workspace_uri, workspace_sid)
+        base_uri = "{0}/{1}".format(self.workspace_uri, workspace_sid)
         return Workflows(base_uri, self.auth, self.timeout)

--- a/twilio/rest/exceptions.py
+++ b/twilio/rest/exceptions.py
@@ -66,4 +66,4 @@ class TwilioRestException(TwilioException):
                 ])
             return msg
         else:
-            return "HTTP {} error: {}".format(self.status, self.msg)
+            return "HTTP {0} error: {1}".format(self.status, self.msg)

--- a/twilio/rest/resources/base.py
+++ b/twilio/rest/resources/base.py
@@ -178,8 +178,8 @@ class Resource(object):
         self.timeout = timeout
 
     def __eq__(self, other):
-        return (isinstance(other, self.__class__)
-                and self.__dict__ == other.__dict__)
+        return (isinstance(other, self.__class__) and
+                self.__dict__ == other.__dict__)
 
     def __hash__(self):
         return hash(frozenset(self.__dict__))
@@ -244,8 +244,8 @@ class InstanceResource(Resource):
             del entries["uri"]
 
         for key in entries.keys():
-            if (key.startswith("date_")
-                    and isinstance(entries[key], string_types)):
+            if (key.startswith("date_") and
+                    isinstance(entries[key], string_types)):
                 entries[key] = self._parse_date(entries[key])
 
         self.__dict__.update(entries)


### PR DESCRIPTION
Unfortunately we're still stuck on python 2.6 and twilio-python 3.7.0 introduced several python 2.7isms. This pull request changes those so they work on 2.6.

(crossbar-taskmgr)zwhite-mn4:twilio-python zwhite$ nosetests tests/
...................................................................................................................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 323 tests in 0.218s

OK