### PR TITLE
Update Send an SMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ account = "ACXXXXXXXXXXXXXXXXX"
 token = "YYYYYYYYYYYYYYYYYY"
 client = TwilioRestClient(account, token)
 
-message = client.messages.create(to="+12316851234", from_="+15555555555",
+message = client.sms.messages.create(to="+12316851234", from_="+15555555555",
                                  body="Hello there!")
 ```
 


### PR DESCRIPTION
Attempted to send an SMS with client.messages.create but received error "'TwilioRestClient' object has no attribute 'messages'"

Adding 'sms' resolved this error.