### PR TITLE
Fix near lat lon for REST client

### DIFF
--- a/twilio/rest/resources/phone_numbers.py
+++ b/twilio/rest/resources/phone_numbers.py
@@ -92,6 +92,11 @@ class AvailablePhoneNumbers(ListResource):
         kwargs["in_postal_code"] = kwargs.get("in_postal_code", postal_code)
         kwargs["in_lata"] = kwargs.get("in_lata", lata)
         kwargs["in_rate_center"] = kwargs.get("in_rate_center", rate_center)
+
+        if "near_lat_long" in kwargs:
+            coord_strings = [str(coord) for coord in kwargs["near_lat_long"]]
+            kwargs["near_lat_long"] = ",".join(coord_strings)
+
         params = transform_params(kwargs)
 
         uri = "%s/%s/%s" % (self.uri, country, TYPES[type])


### PR DESCRIPTION
the "near_lat_long" parameter doesn't actually work for the `search()` method.  The API takes a string like "42.0046,-93.2140" but it currently passes `NearLatLong=42.0046&NearLatLong=-93.2140` as GET parameters