### PR TITLE
Loading Reservations under a Worker by default in TaskRouter JS SDK

### DIFF
--- a/tests/task_router/test_capability.py
+++ b/tests/task_router/test_capability.py
@@ -59,6 +59,20 @@ class TaskRouterCapabilityTest(unittest.TestCase):
         )
         expected = [
             {
+                'url': websocket_url,
+                'method': 'GET',
+                'allow': True,
+                'query_filter': {},
+                'post_filter': {},
+            },
+            {
+                'url': websocket_url,
+                'method': 'POST',
+                'allow': True,
+                'query_filter': {},
+                'post_filter': {},
+            },
+            {
                 'url': 'https://taskrouter.twilio.com/v1/Workspaces/WS456/Activities',
                 'method': 'GET',
                 'allow': True,
@@ -73,15 +87,8 @@ class TaskRouterCapabilityTest(unittest.TestCase):
                 'post_filter': {},
             },
             {
-                'url': websocket_url,
+                'url': 'https://taskrouter.twilio.com/v1/Workspaces/{0}/Workers/{1}/Reservations/**'.format(self.workspace_sid, self.worker_sid),
                 'method': 'GET',
-                'allow': True,
-                'query_filter': {},
-                'post_filter': {},
-            },
-            {
-                'url': websocket_url,
-                'method': 'POST',
                 'allow': True,
                 'query_filter': {},
                 'post_filter': {},

--- a/tests/task_router/test_task_router_capability.py
+++ b/tests/task_router/test_task_router_capability.py
@@ -72,14 +72,15 @@ class TaskRouterCapabilityTest(unittest.TestCase):
         self.check_decoded(decoded, account_sid, workspace_sid, worker_sid, worker_sid)
 
         policies = decoded['policies']
-        self.assertEqual(len(policies), 5)
+        self.assertEqual(len(policies), 6)
 
         for method, url, policy in [
-            ('GET', "https://taskrouter.twilio.com/v1/Workspaces/WS456/Activities", policies[0]),
-            ('GET', "https://taskrouter.twilio.com/v1/Workspaces/WS456/Tasks/**", policies[1]),
-            ('GET', "https://taskrouter.twilio.com/v1/wschannels/AC123/WK789", policies[2]),
-            ('POST', "https://event-bridge.twilio.com/v1/wschannels/AC123/WK789", policies[3]),
-            ('GET', "https://taskrouter.twilio.com/v1/Workspaces/WS456/Workers/WK789", policies[4])
+            ('GET', "https://event-bridge.twilio.com/v1/wschannels/AC123/WK789", policies[0]),
+            ('POST', "https://event-bridge.twilio.com/v1/wschannels/AC123/WK789", policies[1]),
+            ('GET', "https://taskrouter.twilio.com/v1/Workspaces/WS456/Workers/WK789", policies[2])
+            ('GET', "https://taskrouter.twilio.com/v1/Workspaces/WS456/Activities", policies[3]),
+            ('GET', "https://taskrouter.twilio.com/v1/Workspaces/WS456/Tasks/**", policies[4]),
+            ('GET', "https://taskrouter.twilio.com/v1/Workspaces/WS456/Workers/WK789/Reservations/**", policies[5])
         ]:
             yield self.check_policy, method, url, policy
 
@@ -128,15 +129,16 @@ class TaskRouterCapabilityTest(unittest.TestCase):
         self.check_decoded(decoded, account_sid, workspace_sid, worker_sid, worker_sid)
 
         policies = decoded['policies']
-        self.assertEqual(len(policies), 5)
+        self.assertEqual(len(policies), 6)
 
-        # should expect 5 policies
+        # should expect 6 policies
         for method, url, policy in [
-            ('GET', "https://taskrouter.twilio.com/v1/Workspaces/WS456/Activities", policies[0]),
-            ('GET', "https://taskrouter.twilio.com/v1/Workspaces/WS456/Tasks/**", policies[1]),
-            ('GET', "https://event-bridge.twilio.com/v1/wschannels/AC123/WK789", policies[2]),
-            ('POST', "https://event-bridge.twilio.com/v1/wschannels/AC123/WK789", policies[3]),
-            ('GET', "https://taskrouter.twilio.com/v1/Workspaces/WS456/Workers/WK789", policies[4])
+            ('GET', "https://event-bridge.twilio.com/v1/wschannels/AC123/WK789", policies[0]),
+            ('POST', "https://event-bridge.twilio.com/v1/wschannels/AC123/WK789", policies[1]),
+            ('GET', "https://taskrouter.twilio.com/v1/Workspaces/WS456/Activities", policies[2]),
+            ('GET', "https://taskrouter.twilio.com/v1/Workspaces/WS456/Tasks/**", policies[3]),
+            ('GET', "https://taskrouter.twilio.com/v1/Workspaces/WS456/Workers/WK789/Reservations/**", policies[4]),
+            ('GET', "https://taskrouter.twilio.com/v1/Workspaces/WS456/Workers/WK789", policies[5])
         ]:
             yield self.check_policy, method, url, policy
 

--- a/tests/task_router/test_task_router_worker_capability.py
+++ b/tests/task_router/test_task_router_worker_capability.py
@@ -72,17 +72,18 @@ class TaskRouterWorkerCapabilityTest(unittest.TestCase):
 
         websocket_url = 'https://event-bridge.twilio.com/v1/wschannels/{0}/{1}'.format(self.account_sid, self.worker_sid)
 
-        # expect 5 policies
+        # expect 6 policies
         policies = decoded['policies']
-        self.assertEqual(len(policies), 5)
+        self.assertEqual(len(policies), 6)
 
-        # should expect 5 policies
+        # should expect 6 policies
         for method, url, policy in [
             ('GET', websocket_url, policies[0]),
             ('POST', websocket_url, policies[1]),
             ('GET', "https://taskrouter.twilio.com/v1/Workspaces/WS456/Workers/WK789", policies[2]),
-            ('GET', "https://taskrouter.twilio.com/v1/Workspaces/WS456/Tasks/**", policies[3]),
-            ('GET', "https://taskrouter.twilio.com/v1/Workspaces/WS456/Activities", policies[4])
+            ('GET', "https://taskrouter.twilio.com/v1/Workspaces/WS456/Activities", policies[3])
+            ('GET', "https://taskrouter.twilio.com/v1/Workspaces/WS456/Tasks/**", policies[4]),
+            ('GET', "https://taskrouter.twilio.com/v1/Workspaces/WS456/Workers/WK789/Reservations/**", policies[5])
         ]:
             yield self.check_policy, method, url, policy
 
@@ -98,8 +99,8 @@ class TaskRouterWorkerCapabilityTest(unittest.TestCase):
         self.assertNotEqual(None, decoded)
 
         policies = decoded['policies']
-        self.assertEqual(len(policies), 6)
-        policy = policies[5]
+        self.assertEqual(len(policies), 7)
+        policy = policies[6]
 
         url = "https://taskrouter.twilio.com/v1/Workspaces/{0}/Workers/{1}".format(self.workspace_sid, self.worker_sid)
 
@@ -121,13 +122,15 @@ class TaskRouterWorkerCapabilityTest(unittest.TestCase):
         self.assertNotEqual(None, decoded)
 
         policies = decoded['policies']
-        self.assertEqual(len(policies), 6)
+        self.assertEqual(len(policies), 8)
 
-        policy = policies[5]
+        taskPolicy = policies[6]
+        tasksUrl = "https://taskrouter.twilio.com/v1/Workspaces/{0}/Tasks/**".format(self.workspace_sid)
+        self.check_policy('POST', tasksUrl, taskPolicy)
 
-        url = "https://taskrouter.twilio.com/v1/Workspaces/{0}/Tasks/**".format(self.workspace_sid)
-
-        self.check_policy('POST', url, policy)
+        workerReservationsPolicy = policies[7]
+        reservationsUrl = "https://taskrouter.twilio.com/v1/Workspaces/{0}/Workers/{1}/Reservations/**".format(self.workspace_sid, self.worker_sid)
+        self.check_policy('POST', reservationsUrl, workerReservationsPolicy)
 
 if __name__ == "__main__":
     unittest.main()

--- a/twilio/task_router/__init__.py
+++ b/twilio/task_router/__init__.py
@@ -228,13 +228,13 @@ class TaskRouterWorkerCapability(TaskRouterCapability):
                                                          worker_sid)
 
         self.activity_url = self.base_url + "/Activities"
-        self.tasks_url = self.base_url + "/Tasks/**"
+        self.reservations_url = self.base_url + "/Tasks/**"
         self.worker_reservations_url = self.resource_url + "/Reservations/**"
 
         # add permissions to fetch the
         # list of activities, tasks, and worker reservations
         self.allow(self.activity_url, "GET")
-        self.allow(self.tasks_url, "GET")
+        self.allow(self.reservations_url, "GET")
         self.allow(self.worker_reservations_url, "GET")
 
     def setup_resource(self):
@@ -249,7 +249,7 @@ class TaskRouterWorkerCapability(TaskRouterCapability):
 
     def allow_reservation_updates(self):
         self.policies.append(self.make_policy(
-            self.tasks_url,
+            self.reservations_url,
             'POST',
             True))
         self.policies.append(self.make_policy(

--- a/twilio/task_router/__init__.py
+++ b/twilio/task_router/__init__.py
@@ -39,11 +39,11 @@ class TaskRouterCapability(object):
         # validate the JWT
         self.validate_jwt()
 
-        # set up resources
-        self.setup_resource()
-
         # add permissions to GET and POST to the event-bridge channel
         self.allow_web_sockets(channel_id)
+
+        # set up resources
+        self.setup_resource()
 
         # add permissions to fetch the instance resource
         self.add_policy(self.resource_url, "GET", True)
@@ -61,8 +61,11 @@ class TaskRouterCapability(object):
             activity_url = self.base_url + "/Activities"
             self.allow(activity_url, "GET")
 
-            reservations_url = self.base_url + "/Tasks/**"
-            self.allow(reservations_url, "GET")
+            tasks_url = self.base_url + "/Tasks/**"
+            self.allow(tasks_url, "GET")
+
+            worker_reservations_url = self.resource_url + "/Reservations/**"
+            self.allow(worker_reservations_url, "GET")
 
         elif self.channel_prefix == "WQ":
             self.resource_url = "{0}/TaskQueues/{1}".format(
@@ -209,13 +212,15 @@ class TaskRouterWorkerCapability(TaskRouterCapability):
                                                          workspace_sid,
                                                          worker_sid)
 
-        self.reservations_url = self.base_url + "/Tasks/**"
         self.activity_url = self.base_url + "/Activities"
+        self.tasks_url = self.base_url + "/Tasks/**"
+        self.worker_reservations_url = self.resource_url + "/Reservations/**"
 
-        # add permissions to fetch the list of activities and
-        # list of worker reservations
-        self.allow(self.reservations_url, "GET")
+        # add permissions to fetch the
+        # list of activities, tasks, and worker reservations
         self.allow(self.activity_url, "GET")
+        self.allow(self.tasks_url, "GET")
+        self.allow(self.worker_reservations_url, "GET")
 
     def setup_resource(self):
         self.resource_url = self.base_url + "/Workers/" + self.channel_id
@@ -229,7 +234,11 @@ class TaskRouterWorkerCapability(TaskRouterCapability):
 
     def allow_reservation_updates(self):
         self.policies.append(self.make_policy(
-            self.reservations_url,
+            self.tasks_url,
+            'POST',
+            True))
+        self.policies.append(self.make_policy(
+            self.worker_reservations_url,
             'POST',
             True))
 

--- a/twilio/task_router/__init__.py
+++ b/twilio/task_router/__init__.py
@@ -1,6 +1,21 @@
 import time
 from .. import jwt
 
+from .taskrouter_config import (
+    TaskRouterConfig
+)
+
+from .workflow_config import (
+    WorkflowConfig
+)
+
+from .workflow_ruletarget import (
+    WorkflowRuleTarget
+)
+from .workflow_rule import (
+    WorkflowRule
+)
+
 import warnings
 warnings.simplefilter('always', DeprecationWarning)
 
@@ -257,18 +272,3 @@ class TaskRouterWorkspaceCapability(TaskRouterCapability):
 
     def setup_resource(self):
         self.resource_url = self.base_url
-
-from .taskrouter_config import (
-    TaskRouterConfig
-)
-
-from .workflow_config import (
-    WorkflowConfig
-)
-
-from .workflow_ruletarget import (
-    WorkflowRuleTarget
-)
-from .workflow_rule import (
-    WorkflowRule
-)


### PR DESCRIPTION
- Allow fetching Reservations under a Worker by default
- Allow updating Reservations under a Worker