### PR TITLE
Queue stats priority

### DIFF
--- a/tests/resources/task_router/task_queues_statistics_instance.json
+++ b/tests/resources/task_router/task_queues_statistics_instance.json
@@ -21,6 +21,9 @@
             "assigned": 1,
             "reserved": 0
         },
+        "tasks_by_priority": {
+            "Priority-5"
+        }
         "activity_statistics": [
             {
                 "sid": "WA36da5e4272ecadef27920fa475617394",

--- a/tests/resources/task_router/task_queues_statistics_instance.json
+++ b/tests/resources/task_router/task_queues_statistics_instance.json
@@ -23,7 +23,7 @@
         },
         "tasks_by_priority": {
             "Priority-5"
-        }
+        },
         "activity_statistics": [
             {
                 "sid": "WA36da5e4272ecadef27920fa475617394",

--- a/tests/resources/task_router/task_queues_statistics_instance.json
+++ b/tests/resources/task_router/task_queues_statistics_instance.json
@@ -22,7 +22,7 @@
             "reserved": 0
         },
         "tasks_by_priority": {
-            "Priority-5"
+            "Priority-5":1
         },
         "activity_statistics": [
             {

--- a/tests/resources/task_router/task_queues_statistics_list.json
+++ b/tests/resources/task_router/task_queues_statistics_list.json
@@ -33,6 +33,7 @@
                     "assigned": 0,
                     "reserved": 0
                 },
+                "tasks_by_priority":{},
                 "activity_statistics": [
                     {
                         "sid": "WA79bcc984ca4fe04a31f2f91807a53ca0",

--- a/tests/resources/task_router/workflows_statistics_instance.json
+++ b/tests/resources/task_router/workflows_statistics_instance.json
@@ -7,6 +7,9 @@
             "pending": 0,
             "assigned": 1,
             "reserved": 0
+        },
+        "tasks_by_priority": {
+            "Priority-5":1
         }
     },
     "account_sid": "ACe0228445f532b79547997ce0a552cc7a",

--- a/tests/resources/task_router/workspaces_statistics_instance.json
+++ b/tests/resources/task_router/workspaces_statistics_instance.json
@@ -21,6 +21,9 @@
             "assigned": 1,
             "reserved": 0
         },
+        "tasks_by_priority":{
+            "Priority-5":1
+        },
         "activity_statistics": [
             {
                 "sid": "WA36da5e4272ecadef27920fa475617394",

--- a/twilio/task_router/__init__.py
+++ b/twilio/task_router/__init__.py
@@ -1,3 +1,8 @@
+from .taskrouter_config import TaskRouterConfig
+from .workflow_config import WorkflowConfig
+from .workflow_ruletarget import WorkflowRuleTarget
+from .workflow_rule import WorkflowRule
+
 import time
 from .. import jwt
 
@@ -248,18 +253,3 @@ class TaskRouterWorkspaceCapability(TaskRouterCapability):
 
     def setup_resource(self):
         self.resource_url = self.base_url
-
-from .taskrouter_config import (
-    TaskRouterConfig
-)
-
-from .workflow_config import (
-    WorkflowConfig
-)
-
-from .workflow_ruletarget import (
-    WorkflowRuleTarget
-)
-from .workflow_rule import (
-    WorkflowRule
-)


### PR DESCRIPTION
GET request to TaskQueue, Workflow and Workspace Statistics will have a field "tasks_by_priority" under RealTime Stats, similar to the "tasks_by_status" field. 

Example: 
"tasks_by_priority": {"Priority-5":1}