### PR TITLE
Fix phone call -> message copypasta

### DIFF
--- a/twilio/rest/resources/messages.py
+++ b/twilio/rest/resources/messages.py
@@ -116,7 +116,7 @@ class Messages(ListResource):
         :param status_callback: A URL that Twilio will POST to when
             your message is processed.
         :param str application_sid: The 34 character sid of the application
-            Twilio should use to handle this phone call.
+            Twilio should use to handle this message.
         """
         kwargs["from"] = from_
         return self.create_instance(kwargs)


### PR DESCRIPTION
I ran into this when trying to find the actual field name in the SDK for `MessagingServiceSid` that the [docs](https://www.twilio.com/docs/api/rest/sending-messages) reference. It seems to be a typo from copying and pasting `calls.py`. :smiley: 