### PR TITLE
Add Sync grant support

### DIFF
--- a/tests/unit/jwt/test_jwt.py
+++ b/tests/unit/jwt/test_jwt.py
@@ -114,4 +114,4 @@ class JwtTest(unittest.TestCase):
         self.assertRaises(jwt.DecodeError, jwt.decode, jwt_message)
 
     def test_invalid_crypto_alg(self):
-        self.assertRaises(NotImplementedError, jwt.encode, self.payload, "secret", "HS1024")
+        self.assertRaises(NotImplementedError, jwt.encode, self.payload, "secret", {}, "HS1024")

--- a/tests/unit/test_access_token.py
+++ b/tests/unit/test_access_token.py
@@ -1,0 +1,123 @@
+import time
+import unittest
+
+from datetime import datetime
+from nose.tools import assert_equal
+from twilio.jwt import decode
+from twilio.access_token import AccessToken, ConversationsGrant, IpMessagingGrant, SyncGrant
+
+ACCOUNT_SID = 'AC123'
+SIGNING_KEY_SID = 'SK123'
+
+
+# python2.6 support
+def assert_is_not_none(obj):
+    assert obj is not None, '%r is None' % obj
+
+
+def assert_in(obj1, obj2):
+    assert obj1 in obj2, '%r is not in %r' % (obj1, obj2)
+
+
+def assert_greater_equal(obj1, obj2):
+    assert obj1 > obj2, '%r is not greater than or equal to %r' % (obj1, obj2)
+
+
+class AccessTokenTest(unittest.TestCase):
+    def _validate_claims(self, payload):
+        assert_equal(SIGNING_KEY_SID, payload['iss'])
+        assert_equal(ACCOUNT_SID, payload['sub'])
+
+        assert_is_not_none(payload['exp'])
+        assert_is_not_none(payload['jti'])
+        assert_is_not_none(payload['grants'])
+
+        assert_greater_equal(payload['exp'], int(time.time()))
+
+        assert_in(payload['iss'], payload['jti'])
+
+    def test_empty_grants(self):
+        scat = AccessToken(ACCOUNT_SID, SIGNING_KEY_SID, 'secret')
+        token = str(scat)
+
+        assert_is_not_none(token)
+        payload = decode(token, 'secret')
+        self._validate_claims(payload)
+        assert_equal({}, payload['grants'])
+
+    def test_nbf(self):
+        now = int(time.mktime(datetime.now().timetuple()))
+        scat = AccessToken(ACCOUNT_SID, SIGNING_KEY_SID, 'secret', nbf=now)
+        token = str(scat)
+
+        assert_is_not_none(token)
+        payload = decode(token, 'secret')
+        self._validate_claims(payload)
+        assert_equal(now, payload['nbf'])
+
+    def test_identity(self):
+        scat = AccessToken(ACCOUNT_SID, SIGNING_KEY_SID, 'secret', identity='test@twilio.com')
+        token = str(scat)
+
+        assert_is_not_none(token)
+        payload = decode(token, 'secret')
+        self._validate_claims(payload)
+        assert_equal({
+            'identity': 'test@twilio.com'
+        }, payload['grants'])
+
+    def test_conversations_grant(self):
+        scat = AccessToken(ACCOUNT_SID, SIGNING_KEY_SID, 'secret')
+        scat.add_grant(ConversationsGrant(configuration_profile_sid='CP123'))
+
+        token = str(scat)
+        assert_is_not_none(token)
+        payload = decode(token, 'secret')
+        self._validate_claims(payload)
+        assert_equal(1, len(payload['grants']))
+        assert_equal({
+            'configuration_profile_sid': 'CP123'
+        }, payload['grants']['rtc'])
+
+    def test_ip_messaging_grant(self):
+        scat = AccessToken(ACCOUNT_SID, SIGNING_KEY_SID, 'secret')
+        scat.add_grant(IpMessagingGrant(service_sid='IS123', push_credential_sid='CR123'))
+
+        token = str(scat)
+        assert_is_not_none(token)
+        payload = decode(token, 'secret')
+        self._validate_claims(payload)
+        assert_equal(1, len(payload['grants']))
+        assert_equal({
+            'service_sid': 'IS123',
+            'push_credential_sid': 'CR123'
+        }, payload['grants']['ip_messaging'])
+
+    def test_sync_grant(self):
+        scat = AccessToken(ACCOUNT_SID, SIGNING_KEY_SID, 'secret')
+        scat.add_grant(SyncGrant(service_sid='IS123', endpoint_id='some-endpoint'))
+
+        token = str(scat)
+        assert_is_not_none(token)
+        payload = decode(token, 'secret')
+        self._validate_claims(payload)
+        assert_equal(1, len(payload['grants']))
+        assert_equal({
+            'service_sid': 'IS123',
+            'endpoint_id': 'some-endpoint'
+        }, payload['grants']['data_sync'])
+
+    def test_grants(self):
+        scat = AccessToken(ACCOUNT_SID, SIGNING_KEY_SID, 'secret')
+        scat.add_grant(ConversationsGrant())
+        scat.add_grant(IpMessagingGrant())
+        scat.add_grant(SyncGrant())
+
+        token = str(scat)
+        assert_is_not_none(token)
+        payload = decode(token, 'secret')
+        self._validate_claims(payload)
+        assert_equal(3, len(payload['grants']))
+        assert_equal({}, payload['grants']['rtc'])
+        assert_equal({}, payload['grants']['ip_messaging'])
+        assert_equal({}, payload['grants']['data_sync'])

--- a/twilio/access_token.py
+++ b/twilio/access_token.py
@@ -29,6 +29,33 @@ class IpMessagingGrant(object):
         return grant
 
 
+class SyncGrant(object):
+    """ Grant to access Twilio Sync """
+    def __init__(self, service_sid=None, endpoint_id=None,
+                 deployment_role_sid=None, push_credential_sid=None):
+        self.service_sid = service_sid
+        self.endpoint_id = endpoint_id
+        self.deployment_role_sid = deployment_role_sid
+        self.push_credential_sid = push_credential_sid
+
+    @property
+    def key(self):
+        return "data_sync"
+
+    def to_payload(self):
+        grant = {}
+        if self.service_sid:
+            grant['service_sid'] = self.service_sid
+        if self.endpoint_id:
+            grant['endpoint_id'] = self.endpoint_id
+        if self.deployment_role_sid:
+            grant['deployment_role_sid'] = self.deployment_role_sid
+        if self.push_credential_sid:
+            grant['push_credential_sid'] = self.push_credential_sid
+
+        return grant
+
+
 class ConversationsGrant(object):
     """ Grant to access Twilio Conversations """
     def __init__(self, configuration_profile_sid=None):

--- a/twilio/jwt/__init__.py
+++ b/twilio/jwt/__init__.py
@@ -41,10 +41,11 @@ def base64url_encode(input):
     return base64.urlsafe_b64encode(input).decode('utf-8').replace('=', '')
 
 
-def encode(payload, key, algorithm='HS256'):
+def encode(payload, key, headers={}, algorithm='HS256'):
     segments = []
-    header = {"typ": "JWT", "alg": algorithm}
-    segments.append(base64url_encode(binary(json.dumps(header))))
+    defaultHeaders = {"typ": "JWT", "alg": algorithm}
+    defaultHeaders.update(headers)
+    segments.append(base64url_encode(binary(json.dumps(defaultHeaders))))
     segments.append(base64url_encode(binary(json.dumps(payload))))
     sign_input = '.'.join(segments)
     try:


### PR DESCRIPTION
Add sync grant support.
Also extends JWT class to accept custom headers. It is needed to enable token generator to provide token version field.