### PR TITLE
Add iter function to messages resource

### DIFF
--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1,10 +1,12 @@
 from datetime import date
 import unittest
+from tests.tools import create_mock_json
 
 from mock import patch
 from six import u
 
 from twilio.rest.resources import Messages
+from twilio.rest.resources import ListResource
 
 DEFAULT = {
     'From': None,
@@ -37,6 +39,18 @@ class MessageTest(unittest.TestCase):
             self.resource.list(before=date(2011, 1, 1))
             self.params['DateSent<'] = "2011-01-01"
             mock.assert_called_with(self.params)
+
+
+    def test_iter_params(self):
+        with patch.object(ListResource, 'iter') as mock:
+            self.resource.iter(before=date(2016, 1, 1), after=date(2011,1,1), date_sent=date(2016,2,1), to="+15005551212", from_="+15005559999")
+            self.params['DateSent<'] = "2016-01-01"
+            self.params['DateSent>'] = "2011-01-01"
+            self.params['DateSent'] = "2016-02-01"
+            self.params['To'] = "+15005551212"
+            self.params['From'] = "+15005559999"
+            mock.assert_called_with(**self.params)
+
 
     def test_create(self):
         with patch.object(self.resource, 'create_instance') as mock:

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1,6 +1,5 @@
 from datetime import date
 import unittest
-from tests.tools import create_mock_json
 
 from mock import patch
 from six import u

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -40,17 +40,15 @@ class MessageTest(unittest.TestCase):
             self.params['DateSent<'] = "2011-01-01"
             mock.assert_called_with(self.params)
 
-
     def test_iter_params(self):
         with patch.object(ListResource, 'iter') as mock:
-            self.resource.iter(before=date(2016, 1, 1), after=date(2011,1,1), date_sent=date(2016,2,1), to="+15005551212", from_="+15005559999")
+            self.resource.iter(before=date(2016, 1, 1), after=date(2011, 1, 1), date_sent=date(2016, 2, 1), to="+15005551212", from_="+15005559999")
             self.params['DateSent<'] = "2016-01-01"
             self.params['DateSent>'] = "2011-01-01"
             self.params['DateSent'] = "2016-02-01"
             self.params['To'] = "+15005551212"
             self.params['From'] = "+15005559999"
             mock.assert_called_with(**self.params)
-
 
     def test_create(self):
         with patch.object(self.resource, 'create_instance') as mock:

--- a/twilio/rest/resources/messages.py
+++ b/twilio/rest/resources/messages.py
@@ -144,7 +144,7 @@ class Messages(ListResource):
 
     @normalize_dates
     def iter(self, from_=None, to=None, before=None, after=None,
-            date_sent=None, **kwargs):
+             date_sent=None, **kwargs):
         """
         Returns an iterator of :class:`Call` resources.
 

--- a/twilio/rest/resources/messages.py
+++ b/twilio/rest/resources/messages.py
@@ -142,6 +142,22 @@ class Messages(ListResource):
         kw["DateSent"] = parse_date(date_sent)
         return self.get_instances(kw)
 
+    @normalize_dates
+    def iter(self, from_=None, to=None, before=None, after=None,
+            date_sent=None, **kwargs):
+        """
+        Returns an iterator of :class:`Call` resources.
+
+        :param date after: Only list calls started after this datetime
+        :param date before: Only list calls started before this datetime
+        """
+        kwargs["From"] = from_
+        kwargs["To"] = to
+        kwargs["DateSent<"] = before
+        kwargs["DateSent>"] = after
+        kwargs["DateSent"] = parse_date(date_sent)
+        return super(Messages, self).iter(**kwargs)
+
     def update(self, sid, **kwargs):
         """ Updates the message for the given sid
         :param sid: The sid of the message to update.

--- a/twilio/rest/resources/messages.py
+++ b/twilio/rest/resources/messages.py
@@ -146,7 +146,7 @@ class Messages(ListResource):
     def iter(self, from_=None, to=None, before=None, after=None,
              date_sent=None, **kwargs):
         """
-        Returns an iterator of :class:`Call` resources.
+        Returns an iterator of :class:`Message` resources.
 
         :param date after: Only list calls started after this datetime
         :param date before: Only list calls started before this datetime


### PR DESCRIPTION
Added the `iter` function to the messages resource which allows
the user to specify `DateSent<` and `DateSent>` parameters.
