### PR TITLE
docs and tests shouldnt be packaged and installed with the Twillio lib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         ':python_version=="3.4"': ['pysocks'],
         ':python_version=="3.5"': ['pysocks'],
     },
-    packages = find_packages(),
+    packages = find_packages(exclude=['docs', 'tests*']),
     include_package_data=True,
     classifiers = [
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Without excluding the `tests` folder it gets installed with the library and might (will) cause name collisions for consumers