### PR TITLE
Voice response devx5021 and Python testing, compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ python:
   - "3.5"
   - "3.6"
 install:
+  - pip install virtualenv --upgrade
   - make install
   - make test-install
-script: 
+script:
   - make test

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: clean install analysis test test-install develop docs docs-install
 
 venv:
-	virtualenv venv
+	virtualenv --python=python venv
 
 install: venv
 	. venv/bin/activate; pip install .

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,6 @@ with open('twilio/__init__.py') as f:
 # documentation: http://pypi.python.org/pypi/setuptools
 REQUIRES = ["requests >= 2.0.0", "six", "pytz", "PyJWT >= 1.4.2"]
 
-if sys.version_info < (2, 6):
-    REQUIRES.append('simplejson')
 if sys.version_info < (3, 0):
     REQUIRES.extend(["cryptography >= 1.3.4", "idna >= 2.0.0", "pyOpenSSL >= 0.14"])
 if sys.version_info >= (3, 0):
@@ -46,7 +44,6 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",

--- a/tests/unit/http/test_http_client.py
+++ b/tests/unit/http/test_http_client.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+
+import six
+
+import unittest
+
+import mock
+from mock import patch, Mock
+from requests import Request
+from requests import Session
+
+from twilio.http.http_client import TwilioHttpClient
+
+
+class TestHttpClientRequest(unittest.TestCase):
+
+    def setUp(self):
+        self.session_patcher = patch('twilio.http.http_client.Session')
+
+        self.session_mock = Mock(wraps=Session())
+        self.request_mock = Mock()
+
+        self.session_mock.prepare_request.return_value = self.request_mock
+        self.session_mock.send.return_value = Mock(status_code=200, content=six.u('testing-unicodeΩ≈ç√'))
+        self.request_mock.headers = {}
+
+        session_constructor_mock = self.session_patcher.start()
+        session_constructor_mock.return_value = self.session_mock
+
+        self.client = TwilioHttpClient()
+
+    def tearDown(self):
+        self.session_patcher.stop()
+
+    def test_request_sets_host_header_if_missing(self):
+        self.request_mock.url = 'https://api.twilio.com/'
+        self.request_mock.headers = {'Host': 'other.twilio.com'}
+
+        self.client.request('doesnt matter', 'doesnt matter')
+
+        self.assertEqual('other.twilio.com', self.request_mock.headers['Host'])
+
+    def test_request_with_unicode_response(self):
+        self.request_mock.url = 'https://api.twilio.com/'
+        self.request_mock.headers = {'Host': 'other.twilio.com'}
+
+        response = self.client.request('doesnt matter', 'doesnt matter')
+
+        self.assertEqual('other.twilio.com', self.request_mock.headers['Host'])
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(six.u('testing-unicodeΩ≈ç√'), response.content)

--- a/tests/unit/http/test_validation_client.py
+++ b/tests/unit/http/test_validation_client.py
@@ -1,3 +1,7 @@
+# -*- coding: utf-8 -*-
+
+import six
+
 import unittest
 
 import mock
@@ -76,7 +80,7 @@ class TestValidationClientRequest(unittest.TestCase):
         self.request_mock = Mock()
 
         self.session_mock.prepare_request.return_value = self.request_mock
-        self.session_mock.send.return_value = Mock(status_code=200, content='test')
+        self.session_mock.send.return_value = Mock(status_code=200, content=six.u('testΩ'))
         self.validation_token.return_value.to_jwt.return_value = 'test-token'
         self.request_mock.headers = {}
 
@@ -105,3 +109,14 @@ class TestValidationClientRequest(unittest.TestCase):
 
         self.assertEqual('other.twilio.com', self.request_mock.headers['Host'])
         self.assertEqual('test-token', self.request_mock.headers['Twilio-Client-Validation'])
+
+    def test_request_with_unicode_response(self):
+        self.request_mock.url = 'https://api.twilio.com/'
+        self.request_mock.headers = {'Host': 'other.twilio.com'}
+
+        response = self.client.request('doesnt matter', 'doesnt matter')
+
+        self.assertEqual('other.twilio.com', self.request_mock.headers['Host'])
+        self.assertEqual('test-token', self.request_mock.headers['Twilio-Client-Validation'])
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(six.u('testΩ'), response.content)

--- a/tests/unit/twiml/test_voice_response.py
+++ b/tests/unit/twiml/test_voice_response.py
@@ -333,6 +333,25 @@ class TestConference(TwilioTest):
             '<?xml version="1.0" encoding="UTF-8"?><Response><Dial><Conference beep="false" endConferenceOnExit="true" startConferenceOnEnter="true" waitUrl="">TestConferenceAttributes</Conference></Dial></Response>'
         )
 
+    def test_muted_conference(self):
+        d = Dial()
+        d.conference(
+            'TestConferenceMutedAttribute',
+            beep=False,
+            muted=True,
+            wait_url='',
+            start_conference_on_enter=True,
+            end_conference_on_exit=True
+        )
+
+        r = VoiceResponse()
+        r.append(d)
+
+        assert_equal(
+            self.strip(r),
+            '<?xml version="1.0" encoding="UTF-8"?><Response><Dial><Conference beep="false" endConferenceOnExit="true" muted="true" startConferenceOnEnter="true" waitUrl="">TestConferenceMutedAttribute</Conference></Dial></Response>'
+        )
+
 
 class TestQueue(TwilioTest):
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,8 @@
 [tox]
-envlist = py26, py27, py33, py34, py35, py36, pypy
+envlist = py27, py33, py34, py35, py36, pypy
 
 [testenv]
 deps= -r{toxinidir}/tests/requirements.txt
 commands=
    nosetests \
    []
-

--- a/twilio/http/http_client.py
+++ b/twilio/http/http_client.py
@@ -38,4 +38,4 @@ class TwilioHttpClient(HttpClient):
             timeout=timeout,
         )
 
-        return Response(int(response.status_code), response.content.decode('utf-8'))
+        return Response(int(response.status_code), response.content)

--- a/twilio/http/validation_client.py
+++ b/twilio/http/validation_client.py
@@ -1,9 +1,8 @@
-from urllib.parse import urlparse
-
 from collections import namedtuple
 
 from requests import Request, Session
 
+from twilio.compat import urlparse
 from twilio.http import HttpClient, get_cert_file
 from twilio.http.response import Response
 from twilio.jwt.validation import ClientValidationJwt
@@ -70,7 +69,7 @@ class ValidationClient(HttpClient):
             timeout=timeout,
         )
 
-        return Response(int(response.status_code), response.content.decode('utf-8'))
+        return Response(int(response.status_code), response.content)
 
     def _build_validation_payload(self, request):
         """

--- a/twilio/http/validation_client.py
+++ b/twilio/http/validation_client.py
@@ -1,4 +1,4 @@
-from urlparse import urlparse
+from urllib.parse import urlparse
 
 from collections import namedtuple
 

--- a/twilio/jwt/access_token/grants.py
+++ b/twilio/jwt/access_token/grants.py
@@ -10,13 +10,11 @@ def deprecated(func):
 
     @functools.wraps(func)
     def new_func(*args, **kwargs):
-        warnings.warn_explicit(
-            "Call to deprecated function {}.".format(func.__name__),
-            category=DeprecationWarning,
-            filename=func.func_code.co_filename,
-            lineno=func.func_code.co_firstlineno + 1
-        )
+        warnings.simplefilter('always', DeprecationWarning)
+        warnings.warn("Call to deprecated function {}.".format(func.__name__), category=DeprecationWarning, stacklevel=2)
+        warnings.simplefilter('default', DeprecationWarning)
         return func(*args, **kwargs)
+
     return new_func
 
 

--- a/twilio/twiml/voice_response.py
+++ b/twilio/twiml/voice_response.py
@@ -392,6 +392,7 @@ class Dial(TwiML):
         """
         return self.append(Conference(
             name,
+            muted=muted,
             start_conference_on_enter=start_conference_on_enter,
             end_conference_on_exit=end_conference_on_exit,
             max_participants=max_participants,


### PR DESCRIPTION
* Fixes VoiceResponse.conference does not pass on the `muted` parameter
* Fixes Travis-CI to properly run tests using correct version of Python
* Fixes tests to support both Python 2 and Python 3
* Drops Python 2.6 support (**Breaking Change**)