### PR TITLE
Environment markers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,11 +14,24 @@ with open('twilio/__init__.py') as f:
 # You need to have the setuptools module installed. Try reading the setuptools
 # documentation: http://pypi.python.org/pypi/setuptools
 REQUIRES = ["requests >= 2.0.0", "six", "pytz", "PyJWT >= 1.4.2"]
+REQUIRES_PY2 = ["cryptography >= 1.3.4", "idna >= 2.0.0", "pyOpenSSL >= 0.14"]
+REQUIRES_PY3 = ['pysocks']
 
-if sys.version_info < (3, 0):
-    REQUIRES.extend(["cryptography >= 1.3.4", "idna >= 2.0.0", "pyOpenSSL >= 0.14"])
-if sys.version_info >= (3, 0):
-    REQUIRES.append('pysocks')
+if 'bdist_wheel' not in sys.argv:
+    # Since wheels don't have setup.py but a static list of dependencies,
+    # if install_requires is once made it's fixed to a wheel file.
+    # To prevent fixing the following conditional dependencies, opt-out them
+    # when building wheels and use "environment markers" instead  (see below).
+    if sys.version_info < (3, 0):
+        REQUIRES.extend(REQUIRES_PY2)
+    if sys.version_info >= (3, 0):
+        REQUIRES.extend(REQUIRES_PY3)
+
+# Environment markers
+extras_require = {
+    ":python_version<'3.0'": REQUIRES_PY2,
+    ":python_version>='3.0'": REQUIRES_PY3,
+}
 
 setup(
     name = "twilio",
@@ -30,12 +43,7 @@ setup(
     keywords = ["twilio","twiml"],
     install_requires = REQUIRES,
     # bdist conditional requirements support
-    extras_require={
-        ':python_version=="3.3"': ['pysocks'],
-        ':python_version=="3.4"': ['pysocks'],
-        ':python_version=="3.5"': ['pysocks'],
-        ':python_version=="3.6"': ['pysocks'],
-    },
+    extras_require = extras_require,
     packages = find_packages(exclude=['tests', 'tests.*']),
     include_package_data=True,
     classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ if 'bdist_wheel' not in sys.argv:
 # Environment markers
 extras_require = {
     # Older versions of pip don't support operators other than ==/!=
-    ":python_version=='2.6' or python_version=='2.7'": REQUIRES_PY2,
+    ":python_version=='2.7'": REQUIRES_PY2,
     (":python_version=='3.3' or python_version=='3.4' or"
      " python_version=='3.5' or python_version=='3.6'"): REQUIRES_PY3,
 }

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,7 @@ if 'bdist_wheel' not in sys.argv:
 # Environment markers
 extras_require = {
     # Older versions of pip don't support operators other than ==/!=
-    ":python_version=='2.6'": REQUIRES_PY2,
-    ":python_version=='2.7'": REQUIRES_PY2,
+    ":python_version=='2.6' or python_version=='2.7'": REQUIRES_PY2,
     ":python_version!='2.6' and python_version!='2.7'": REQUIRES_PY3,
 }
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,8 @@ if 'bdist_wheel' not in sys.argv:
 extras_require = {
     # Older versions of pip don't support operators other than ==/!=
     ":python_version=='2.6' or python_version=='2.7'": REQUIRES_PY2,
-    ":python_version!='2.6' and python_version!='2.7'": REQUIRES_PY3,
+    (":python_version=='3.3' or python_version=='3.4' or"
+     " python_version=='3.5' or python_version=='3.6'"): REQUIRES_PY3,
 }
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,10 @@ if 'bdist_wheel' not in sys.argv:
 
 # Environment markers
 extras_require = {
-    ":python_version<'3.0'": REQUIRES_PY2,
-    ":python_version>='3.0'": REQUIRES_PY3,
+    # Older versions of pip don't support operators other than ==/!=
+    ":python_version=='2.6'": REQUIRES_PY2,
+    ":python_version=='2.7'": REQUIRES_PY2,
+    ":python_version!='2.6' and python_version!='2.7'": REQUIRES_PY3,
 }
 
 setup(


### PR DESCRIPTION
This patch aims to fix #356 and some related others.

- As twilio doesn't support Python 2.5 or below, removed simplejson from conditional dependencies.
- Although twilio have used environment markers, it hadn't opt out conditional dependencies when building wheels. If a wheel is once built with Python 3 pip always installs pysocks (which is a conditional dependency only for Python 3) regardless of Python version. Opting out conditional dependencies prevents this problem.
- Although environment markers work well with the recent versions of pip, the older versions of pip lacks the feature.  To make it work on them as well, `if` conditions on setup.py still remains if it's not building wheels.
- As some older versions of pip doesn't have operators like `<`/`>=`, it uses only `==`/`!=`/`and` for backward compatibility.
- Environment markers became more organized and reduced duplicated lists.

Dependencies of build wheels now look like (`"run_requires"` field of twilio-6.3.0.dist-info/metadata.json):

```json
[
  {
    "requires": [
      "PyJWT (>=1.4.2)",
      "pytz",
      "requests (>=2.0.0)",
      "six"
    ]
  },
  {
    "environment": "python_version!='2.6' and python_version!='2.7'",
    "requires": [
      "pysocks"
    ]
  },
  {
    "environment": "python_version=='2.6'",
    "requires": [
      "cryptography (>=1.3.4)",
      "idna (>=2.0.0)",
      "pyOpenSSL (>=0.14)"
    ]
  },
  {
    "environment": "python_version=='2.7'",
    "requires": [
      "cryptography (>=1.3.4)",
      "idna (>=2.0.0)",
      "pyOpenSSL (>=0.14)"
    ]
  }
]
```