### PR TITLE
Fix issue for python 3.5 and lower, json.loads would not accept bytes

### DIFF
--- a/twilio/base/page.py
+++ b/twilio/base/page.py
@@ -58,7 +58,7 @@ class Page(object):
         if response.status_code != 200:
             raise TwilioException('Unable to fetch page', response)
 
-        return json.loads(response.content)
+        return json.loads(response.content.decode('utf-8'))
 
     def load_page(self, payload):
         """

--- a/twilio/base/version.py
+++ b/twilio/base/version.py
@@ -54,7 +54,7 @@ class Version(object):
         """
         # noinspection PyBroadException
         try:
-            error_payload = json.loads(response.content)
+            error_payload = json.loads(response.content.decode('utf-8'))
             if 'message' in error_payload:
                 message = '{}: {}'.format(message, error_payload['message'])
             code = error_payload.get('code', response.status_code)
@@ -81,7 +81,7 @@ class Version(object):
         if response.status_code < 200 or response.status_code >= 300:
             raise self.exception(method, uri, response, 'Unable to fetch record')
 
-        return json.loads(response.content)
+        return json.loads(response.content.decode('utf-8'))
 
     def update(self, method, uri, params=None, data=None, headers=None, auth=None, timeout=None,
                allow_redirects=False):
@@ -102,7 +102,7 @@ class Version(object):
         if response.status_code < 200 or response.status_code >= 300:
             raise self.exception(method, uri, response, 'Unable to update record')
 
-        return json.loads(response.content)
+        return json.loads(response.content.decode('utf-8'))
 
     def delete(self, method, uri, params=None, data=None, headers=None, auth=None, timeout=None,
                allow_redirects=False):
@@ -208,5 +208,5 @@ class Version(object):
         if response.status_code < 200 or response.status_code >= 300:
             raise self.exception(method, uri, response, 'Unable to create record')
 
-        return json.loads(response.content)
+        return json.loads(response.content.decode('utf-8'))
 


### PR DESCRIPTION
The underlying issue seems to have been introduced in d833182e789c9542d067e527729b1c3206bf4867.

Fixes #358.