### PR TITLE
Fix broken Python 3.3, 3.4, and 3.5

### DIFF
--- a/tests/unit/http/test_http_client.py
+++ b/tests/unit/http/test_http_client.py
@@ -10,6 +10,7 @@ from requests import Request
 from requests import Session
 
 from twilio.http.http_client import TwilioHttpClient
+from twilio.http.response import Response
 
 
 class TestHttpClientRequest(unittest.TestCase):
@@ -21,7 +22,7 @@ class TestHttpClientRequest(unittest.TestCase):
         self.request_mock = Mock()
 
         self.session_mock.prepare_request.return_value = self.request_mock
-        self.session_mock.send.return_value = Mock(status_code=200, content=six.u('testing-unicodeΩ≈ç√'))
+        self.session_mock.send.return_value = Response(200, 'testing-unicode: Ω≈ç√, 💩')
         self.request_mock.headers = {}
 
         session_constructor_mock = self.session_patcher.start()
@@ -48,4 +49,4 @@ class TestHttpClientRequest(unittest.TestCase):
 
         self.assertEqual('other.twilio.com', self.request_mock.headers['Host'])
         self.assertEqual(200, response.status_code)
-        self.assertEqual(six.u('testing-unicodeΩ≈ç√'), response.content)
+        self.assertEqual('testing-unicode: Ω≈ç√, 💩', response.content)

--- a/tests/unit/http/test_validation_client.py
+++ b/tests/unit/http/test_validation_client.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import six
-
 import unittest
 
 import mock
@@ -10,6 +8,7 @@ from requests import Request
 from requests import Session
 
 from twilio.http.validation_client import ValidationClient
+from twilio.http.response import Response
 
 
 class TestValidationClientHelpers(unittest.TestCase):
@@ -80,7 +79,7 @@ class TestValidationClientRequest(unittest.TestCase):
         self.request_mock = Mock()
 
         self.session_mock.prepare_request.return_value = self.request_mock
-        self.session_mock.send.return_value = Mock(status_code=200, content=six.u('testΩ'))
+        self.session_mock.send.return_value = Response(200, 'test, omega: Ω, pile of poop: 💩')
         self.validation_token.return_value.to_jwt.return_value = 'test-token'
         self.request_mock.headers = {}
 
@@ -119,4 +118,4 @@ class TestValidationClientRequest(unittest.TestCase):
         self.assertEqual('other.twilio.com', self.request_mock.headers['Host'])
         self.assertEqual('test-token', self.request_mock.headers['Twilio-Client-Validation'])
         self.assertEqual(200, response.status_code)
-        self.assertEqual(six.u('testΩ'), response.content)
+        self.assertEqual('test, omega: Ω, pile of poop: 💩', response.content)

--- a/twilio/base/page.py
+++ b/twilio/base/page.py
@@ -58,7 +58,7 @@ class Page(object):
         if response.status_code != 200:
             raise TwilioException('Unable to fetch page', response)
 
-        return json.loads(response.content)
+        return json.loads(response.text)
 
     def load_page(self, payload):
         """

--- a/twilio/base/version.py
+++ b/twilio/base/version.py
@@ -54,7 +54,7 @@ class Version(object):
         """
         # noinspection PyBroadException
         try:
-            error_payload = json.loads(response.content)
+            error_payload = json.loads(response.text)
             if 'message' in error_payload:
                 message = '{}: {}'.format(message, error_payload['message'])
             code = error_payload.get('code', response.status_code)
@@ -81,7 +81,7 @@ class Version(object):
         if response.status_code < 200 or response.status_code >= 300:
             raise self.exception(method, uri, response, 'Unable to fetch record')
 
-        return json.loads(response.content)
+        return json.loads(response.text)
 
     def update(self, method, uri, params=None, data=None, headers=None, auth=None, timeout=None,
                allow_redirects=False):
@@ -102,7 +102,7 @@ class Version(object):
         if response.status_code < 200 or response.status_code >= 300:
             raise self.exception(method, uri, response, 'Unable to update record')
 
-        return json.loads(response.content)
+        return json.loads(response.text)
 
     def delete(self, method, uri, params=None, data=None, headers=None, auth=None, timeout=None,
                allow_redirects=False):
@@ -208,5 +208,4 @@ class Version(object):
         if response.status_code < 200 or response.status_code >= 300:
             raise self.exception(method, uri, response, 'Unable to create record')
 
-        return json.loads(response.content)
-
+        return json.loads(response.text)

--- a/twilio/http/http_client.py
+++ b/twilio/http/http_client.py
@@ -38,4 +38,4 @@ class TwilioHttpClient(HttpClient):
             timeout=timeout,
         )
 
-        return Response(int(response.status_code), response.content)
+        return Response(int(response.status_code), response.text)

--- a/twilio/http/response.py
+++ b/twilio/http/response.py
@@ -2,11 +2,15 @@ class Response(object):
     """
 
     """
-    def __init__(self, status_code, content):
-        self.content = content
+    def __init__(self, status_code, text):
+        self.content = text
         self.cached = False
         self.status_code = status_code
         self.ok = self.status_code < 400
+
+    @property
+    def text(self):
+        return self.content
 
     def __repr__(self):
         return 'HTTP {} {}'.format(self.status_code, self.content)

--- a/twilio/http/validation_client.py
+++ b/twilio/http/validation_client.py
@@ -69,7 +69,7 @@ class ValidationClient(HttpClient):
             timeout=timeout,
         )
 
-        return Response(int(response.status_code), response.content)
+        return Response(int(response.status_code), response.text)
 
     def _build_validation_payload(self, request):
         """


### PR DESCRIPTION
`json.loads` only accepts `str` types in Python >3 and <3.6, so this PR converts all returned `response.content` objects to `str` from `bytes`.

Fixes #358 
Fixes #359 