### PR TITLE
Basic implementation of HTTP proxy support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,23 @@ Alternately, a `Client` constructor without these parameters will
 look for `TWILIO_ACCOUNT_SID` and `TWILIO_AUTH_TOKEN` variables inside the
 current environment.
 
+#### Proxy Configuration
+
+If you need to configure a proxy to access the Internet, you can set the
+environment variables `HTTP_PROXY` and/or `HTTPS_PROXY`, or alternatively
+pass in a dictionary with the proxy configuration to the client.
+
+```python
+from twilio.rest import Client
+
+proxy_config = {'http': 'http://user:password@example.com:80'}
+account = 'ACXXXXXXXXXXXXX'
+token = 'YYYYYYYYYYYYYYYYY'
+client = Client(account, token, proxies=proxy_config)
+```
+
+Note: proxy urls must include the scheme.
+
 We suggest storing your credentials as environment variables. Why? You'll never
 have to worry about committing your credentials and accidentally posting them
 somewhere public.

--- a/twilio/http/http_proxy_client.py
+++ b/twilio/http/http_proxy_client.py
@@ -1,0 +1,54 @@
+from requests import Request, Session
+
+from twilio.http import get_cert_file
+from twilio.http.response import Response
+
+from .http_client import TwilioHttpClient
+
+
+class TwilioHttpProxyClient(TwilioHttpClient):
+    """
+    Thin wrapper over the base TwilioHttpClient which implements HTTP Proxy support
+    """
+    def __init__(self, proxies=None):
+        """
+        :param dict proxies: A dictionary mapping protocol with proxy information.
+        See Requests documentation for more information
+        """
+        self.proxies = proxies
+
+    def request(self, method, url, params=None, data=None, headers=None, auth=None, timeout=None,
+                allow_redirects=False):
+        """
+        Make an HTTP Request with parameters provided.
+
+        :param str method: The HTTP method to use
+        :param str url: The URL to request
+        :param dict params: Query parameters to append to the URL
+        :param dict data: Parameters to go in the body of the HTTP request
+        :param dict headers: HTTP Headers to send with the request
+        :param tuple auth: Basic Auth arguments
+        :param float timeout: Socket/Read timeout for the request
+        :param boolean allow_redirects: Whether or not to allow redirects
+        See the requests documentation for explanation of all these parameters
+
+        :return: An http response
+        :rtype: A :class:`Response <twilio.rest.http.response.Response>` object
+        """
+        session = Session()
+
+        if self.proxies is not None:
+            session.proxies.update(self.proxies)
+
+        session.verify = get_cert_file()
+
+        request = Request(method.upper(), url, params=params, data=data, headers=headers, auth=auth)
+
+        prepped_request = session.prepare_request(request)
+        response = session.send(
+            prepped_request,
+            allow_redirects=allow_redirects,
+            timeout=timeout,
+        )
+
+        return Response(int(response.status_code), response.text)

--- a/twilio/rest/__init__.py
+++ b/twilio/rest/__init__.py
@@ -11,13 +11,14 @@ import platform
 from twilio import __version__
 from twilio.base.exceptions import TwilioException
 from twilio.http.http_client import TwilioHttpClient
+from twilio.http.http_proxy_client import TwilioHttpProxyClient
 
 
 class Client(object):
     """ A client for accessing the Twilio API. """
 
     def __init__(self, username=None, password=None, account_sid=None, region=None,
-                 http_client=None, environment=None):
+                 http_client=None, environment=None, proxies=None):
         """
         Initializes the Twilio Client
 
@@ -47,7 +48,10 @@ class Client(object):
 
         self.auth = (self.username, self.password)
         """ :type : tuple(str, str) """
-        self.http_client = http_client or TwilioHttpClient()
+        if proxies:
+            self.http_client = TwilioHttpProxyClient(proxies=proxies)
+        else:
+            self.http_client = http_client or TwilioHttpClient()
         """ :type : HttpClient """
 
         # Domains


### PR DESCRIPTION
I had to use this client in an environment behind a HTTP proxy, but I was not able to modify the environment.  Requests has excellent proxy support; so I wrote this small wrapper over the standard http client, and modified the rest client to accept optional proxy configuration that is not read from the environment.