### PR TITLE
PyJWT >= 1.5.1 exception fixed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     install_requires = [
         "six",
         "pytz",
-        "PyJWT >= 1.4.2, <1.5.1",
+        "PyJWT >= 1.4.2",
     ],
     extras_require={
         ':python_version<"3.0"': [

--- a/twilio/jwt/__init__.py
+++ b/twilio/jwt/__init__.py
@@ -134,8 +134,8 @@ class Jwt(object):
         verify = True if key else False
 
         try:
-            payload = jwt_lib.decode(bytes(jwt), key, verify=verify, options={
-                'verify_signature': True,
+            payload = jwt_lib.decode(bytes(jwt), key, options={
+                'verify_signature': verify,
                 'verify_exp': True,
                 'verify_nbf': True,
             })


### PR DESCRIPTION
Hello. I took the time to trace the following error (caused with PyJWT >= 1.5.1).
This is the same error that resulted in [this being committed](https://github.com/twilio/twilio-python/commit/ae13a244ef0e7059c325533b4cd8fb8c0af5b274).
I **was able** to find out the cause for the exception raised, and **fix the test**.
#### But you should verify that works for you, as I didn't check how it fits into your package.

~**_Also,_ this fix is probably not backwards compatible for PyJWT.**
As I don't use PyJWT, I can't really come up with that myself easily.
All I can come up with is checking pyjwt's version and deciding what call arguments to use according to that.~
**Edit**: So, it is backwards compatible :)

Disclaimer: I don't actually use twilio or this package. Just thought this might help.

***

### Original test error:
```
ERROR: test_decode_allows_skip_verification (tests.unit.jwt.test_jwt.JwtTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/build/twilio/twilio-python/tests/unit/jwt/test_jwt.py", line 264, in test_decode_allows_skip_verification
    decoded_jwt = Jwt.from_jwt(jwt.to_jwt(), key=None)
  File "/home/travis/build/twilio/twilio-python/twilio/jwt/__init__.py", line 144, in from_jwt
    raise JwtDecodeError(getattr(e, 'message', str(e)))
JwtDecodeError: Expected a string value
```

***

### Call stack:
<details open>
  <summary><strong>Click to expand/collapse call stack</strong></summary>

* `JwtTest.test_decode_allows_skip_verification` in `tests/unit/jwt/test_jwt.py`:
  [source](https://github.com/twilio/twilio-python/blob/2f0f62dc17ee35fbfc643190d2e4df3f22ad55c9/tests/unit/jwt/test_jwt.py#L264)
  ```python
  decoded_jwt = Jwt.from_jwt(jwt.to_jwt(), key=None)
  ```
* `Jwt.from_jwt` in `twilio/jwt/__init__.py`:
  [source](https://github.com/twilio/twilio-python/blob/2f0f62dc17ee35fbfc643190d2e4df3f22ad55c9/twilio/jwt/__init__.py#L137-L141)
  ```python
  payload = jwt_lib.decode(bytes(jwt), key, verify=verify, options={
    'verify_signature': True,
    'verify_exp': True,
    'verify_nbf': True,
  })
  ```
* `PyJWT.decode` in `<pyjwt>/api_jwt.py`:
  [source](https://github.com/jpadilla/pyjwt/blob/1.5.2/jwt/api_jwt.py#L77-L79)
  ```python
  decoded = super(PyJWT, self).decode(
      jwt, key=key, algorithms=algorithms, options=options, **kwargs
  )
  ```
* `PyJWS.decode` in `<pyjwt>/api_jws.py`:
  [source](https://github.com/jpadilla/pyjwt/blob/1.5.2/jwt/api_jws.py#L134-L135)
  ```python
  self._verify_signature(payload, signing_input, header, signature,
                         key, algorithms)
  ```
* `PyJWS._verify_signature` in `<pyjwt>/api_jws.py`:
  [source](https://github.com/jpadilla/pyjwt/blob/1.5.2/jwt/api_jws.py#L203)
  ```python
  key = alg_obj.prepare_key(key)
  ```
* `HMACAlgorithm(HMACAlgorithm.SHA256).prepare_key` in `<pyjwt>/algorithms.py`:
  [source](https://github.com/jpadilla/pyjwt/blob/1.5.2/jwt/algorithms.py#L140)
  ```python
  key = force_bytes(key)
  ```
* `force_bytes` in `<pyjwt>/utils.py`:
  [source](https://github.com/jpadilla/pyjwt/blob/1.5.2/jwt/utils.py#L24-L30)
  ```python
  def force_bytes(value):
      if isinstance(value, text_type):
          return value.encode('utf-8')
      elif isinstance(value, binary_type):
          return value
      else:
          raise TypeError('Expected a string value')
  ```
* As `key` is `None`, it raises the exception.
</details>

***
### Solution:
Now, it seems the verify argument usage has changed in the latest version, in a way that is not backwards compatible, as can be seen in the following diff for PyJWT:
[source](https://github.com/jpadilla/pyjwt/compare/1.5.0...1.5.2/#diff-00ea5fc2260636f8d87435daf8c3b4c7)
```diff
-        decoded = super(PyJWT, self).decode(jwt, key, verify, algorithms,
-                                            options, **kwargs)
+        if options is None:
+            options = {'verify_signature': verify}
+        else:
+            options.setdefault('verify_signature', verify)
+
+        decoded = super(PyJWT, self).decode(
+            jwt, key=key, algorithms=algorithms, options=options, **kwargs
+        )
```

`verify` doesn't actually get passed.
Its value is set into `verify_signature` in options, but only if `options` is `None` or if `options` doesn't have `verify_signature` in it (see `options.setdefault` line)
`Jwt.from_jwt` sets `options`, and that's why `verify` wasn't being honoured in `PyJWT.decode`.

And so, by modifying the code as suggested in this PR, I was able to get the failing test to pass.

Hope this helps you solve the issues :)