### PR TITLE
Allow user to turn off nbf generation in jwts

### DIFF
--- a/tests/unit/jwt/test_jwt.py
+++ b/tests/unit/jwt/test_jwt.py
@@ -10,8 +10,8 @@ from twilio.jwt import Jwt, JwtDecodeError
 
 class DummyJwt(Jwt):
     """Jwt implementation that allows setting arbitrary payload and headers for testing."""
-    def __init__(self, secret_key, issuer, subject=None, algorithm='HS256', nbf=None, ttl=3600,
-                 valid_until=None, headers=None, payload=None):
+    def __init__(self, secret_key, issuer, subject=None, algorithm='HS256', nbf=Jwt.GENERATE,
+                 ttl=3600, valid_until=None, headers=None, payload=None):
         super(DummyJwt, self).__init__(
             secret_key=secret_key,
             issuer=issuer,
@@ -71,6 +71,18 @@ class JwtTest(unittest.TestCase):
             jwt.to_jwt(), 'secret_key',
             expected_headers={'typ': 'JWT', 'alg': 'HS256'},
             expected_payload={'iss': 'issuer', 'exp': 3600, 'nbf': 0, 'sub': 'subject'},
+        )
+
+    @patch('time.time')
+    def test_encode_without_nbf(self, time_mock):
+        time_mock.return_value = 0.0
+
+        jwt = DummyJwt('secret_key', 'issuer', subject='subject', headers={}, payload={}, nbf=None)
+
+        self.assertJwtsEqual(
+            jwt.to_jwt(), 'secret_key',
+            expected_headers={'typ': 'JWT', 'alg': 'HS256'},
+            expected_payload={'iss': 'issuer', 'exp': 3600, 'sub': 'subject'},
         )
 
     @patch('time.time')

--- a/twilio/jwt/__init__.py
+++ b/twilio/jwt/__init__.py
@@ -26,7 +26,9 @@ class JwtDecodeError(Exception):
 
 class Jwt(object):
     """Base class for building a Json Web Token"""
-    def __init__(self, secret_key, issuer, subject=None, algorithm='HS256', nbf=None,
+    GENERATE = object()
+
+    def __init__(self, secret_key, issuer, subject=None, algorithm='HS256', nbf=GENERATE,
                  ttl=3600, valid_until=None):
         self.secret_key = secret_key
         """:type str: The secret used to encode the JWT"""
@@ -80,8 +82,12 @@ class Jwt(object):
 
         payload = self._generate_payload().copy()
         payload['iss'] = self.issuer
-        payload['nbf'] = self.nbf or int(time.time())
         payload['exp'] = int(time.time()) + self.ttl
+        if self.nbf is not None:
+            if self.nbf == self.GENERATE:
+                payload['nbf'] = int(time.time())
+            else:
+                payload['nbf'] = self.nbf
         if self.valid_until:
             payload['exp'] = self.valid_until
         if self.subject:

--- a/twilio/jwt/access_token/__init__.py
+++ b/twilio/jwt/access_token/__init__.py
@@ -21,7 +21,7 @@ class AccessTokenGrant(object):
 class AccessToken(Jwt):
     """Access Token containing one or more AccessTokenGrants used to access Twilio Resources"""
     def __init__(self, account_sid, signing_key_sid, secret, grants=None,
-                 identity=None, nbf=None, ttl=3600, valid_until=None):
+                 identity=None, nbf=Jwt.GENERATE, ttl=3600, valid_until=None):
         grants = grants or []
         if any(not isinstance(g, AccessTokenGrant) for g in grants):
             raise ValueError('Grants must be instances of AccessTokenGrant.')

--- a/twilio/jwt/client/__init__.py
+++ b/twilio/jwt/client/__init__.py
@@ -7,7 +7,8 @@ from twilio.compat import urlencode
 class ClientCapabilityToken(Jwt):
     """A token to control permissions with Twilio Client"""
 
-    def __init__(self, account_sid, auth_token, nbf=None, ttl=3600, valid_until=None, **kwargs):
+    def __init__(self, account_sid, auth_token, nbf=Jwt.GENERATE, ttl=3600, valid_until=None,
+                 **kwargs):
         """
         :param str account_sid: The account sid to which this token is granted access.
         :param str auth_token: The secret key used to sign the token. Note, this auth token is not

--- a/twilio/jwt/taskrouter/__init__.py
+++ b/twilio/jwt/taskrouter/__init__.py
@@ -29,7 +29,7 @@ class TaskRouterCapabilityToken(Jwt):
             secret_key=auth_token,
             issuer=account_sid,
             algorithm='HS256',
-            nbf=kwargs.get('nbf', None),
+            nbf=kwargs.get('nbf', Jwt.GENERATE),
             ttl=kwargs.get('ttl', 3600),
             valid_until=kwargs.get('valid_until', None),
         )


### PR DESCRIPTION
We have had reports that nbf causes problems because if they arent provided they would take the local system time, however since they are validated on twilio's servers that requires that the system that generated the jwt and the system that validates it have relatively synced clocks which cannot be guaranteed.

Nbf will continue to be set if the user passes it on construction.