### PR TITLE
Only strip port 443 from SSL URL during validation

### DIFF
--- a/tests/unit/test_request_validator.py
+++ b/tests/unit/test_request_validator.py
@@ -62,6 +62,11 @@ class ValidationTest(unittest.TestCase):
         assert_true(self.validator.validate(self.uri, self.params, expected))
 
     def test_validation_removes_port_on_https(self):
-        self.uri = "https://www.postbin.org:1234/1ed898x"
+        self.uri = "https://www.postbin.org:443/1ed898x"
         expected = "Y7MeICc5ECftd1G11Fc8qoxAn0A="
+        assert_true(self.validator.validate(self.uri, self.params, expected))
+
+    def test_validation_leaves_port_on_non_standard_https(self):
+        self.uri = "https://www.postbin.org:1234/1ed898x"
+        expected = "xrqSgQsuj6s/mVHMrrgDsdWJjiE="
         assert_true(self.validator.validate(self.uri, self.params, expected))

--- a/twilio/request_validator.py
+++ b/twilio/request_validator.py
@@ -74,6 +74,6 @@ class RequestValidator(object):
         :returns: True if the request passes validation, False if not
         """
         parsed_uri = urlparse(uri)
-        if parsed_uri.scheme == "https" and parsed_uri.port:
+        if parsed_uri.scheme == "https" and parsed_uri.port == 443:
             uri = remove_port(parsed_uri)
         return compare(self.compute_signature(uri, params), signature)


### PR DESCRIPTION
Fixes request validation failures over SSL on non standard ports.

Request validation uses a concatenation of the URL and message body for hashing. SSL requests on port 443 have the port number removed from the URL. SSL requests on non standard ports retain the port number.