### PR TITLE
Add missing dependencies for running tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
+flake8
+mock
+nose
 six
 requests>=2.0.0
 socksipy-branch


### PR DESCRIPTION
I was trying to run `make test` and found I needed these dependencies installed into my virtual environment in order to get the tests to run and pass.