### PR TITLE
Add incoming.allow to AccessToken VoiceGrant

### DIFF
--- a/tests/unit/jwt/test_access_token.py
+++ b/tests/unit/jwt/test_access_token.py
@@ -190,6 +190,25 @@ class AccessTokenTest(unittest.TestCase):
             }
         }, decoded_token.payload['grants']['voice'])
 
+    def test_programmable_voice_grant_incoming(self):
+        grant = VoiceGrant(
+            incoming_allow=True
+        )
+
+        scat = AccessToken(ACCOUNT_SID, SIGNING_KEY_SID, 'secret')
+        scat.add_grant(grant)
+
+        token = scat.to_jwt()
+        assert_is_not_none(token)
+        decoded_token = AccessToken.from_jwt(token, 'secret')
+        self._validate_claims(decoded_token.payload)
+        assert_equal(1, len(decoded_token.payload['grants']))
+        assert_equal({
+            'incoming': {
+                'allow': True
+            }
+        }, decoded_token.payload['grants']['voice'])
+
     def test_task_router_grant(self):
         grant = TaskRouterGrant(
             workspace_sid='WS123',

--- a/twilio/jwt/access_token/grants.py
+++ b/twilio/jwt/access_token/grants.py
@@ -98,10 +98,13 @@ class SyncGrant(AccessTokenGrant):
 class VoiceGrant(AccessTokenGrant):
     """Grant to access Twilio Programmable Voice"""
     def __init__(self,
+                 incoming_allow=None,
                  outgoing_application_sid=None,
                  outgoing_application_params=None,
                  push_credential_sid=None,
                  endpoint_id=None):
+        self.incoming_allow = incoming_allow
+        """ :type : bool """
         self.outgoing_application_sid = outgoing_application_sid
         """ :type : str """
         self.outgoing_application_params = outgoing_application_params
@@ -117,6 +120,10 @@ class VoiceGrant(AccessTokenGrant):
 
     def to_payload(self):
         grant = {}
+        if self.incoming_allow is True:
+            grant['incoming'] = {}
+            grant['incoming']['allow'] = True
+
         if self.outgoing_application_sid:
             grant['outgoing'] = {}
             grant['outgoing']['application_sid'] = self.outgoing_application_sid


### PR DESCRIPTION
https://issues.corp.twilio.com/browse/CLIENT-4492

To support JS Clients per this spec:
https://paper.dropbox.com/doc/Proposal-FPA-Token-Format-for-Programmable-Voice-SDKs-xhdFHD6N3aPW9GRp4dXNX