### PR TITLE
Remove Python 3.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",


### PR DESCRIPTION
Python 3.3 was EOL-ed on September 29, 2017. This PR removes testing against Python 3.3, as Travis also no longer supports Python 3.3 correctly.