### PR TITLE
Add method to validate ssl certificate

### DIFF
--- a/tests/unit/http/test_validation_client.py
+++ b/tests/unit/http/test_validation_client.py
@@ -10,7 +10,6 @@ from requests import Session
 from twilio.base.exceptions import TwilioRestException
 from twilio.http.validation_client import ValidationClient
 from twilio.http.response import Response
-from twilio.http.http_client import TwilioHttpClient
 
 
 class TestValidationClientHelpers(unittest.TestCase):

--- a/tests/unit/http/test_validation_client.py
+++ b/tests/unit/http/test_validation_client.py
@@ -121,14 +121,14 @@ class TestValidationClientRequest(unittest.TestCase):
         self.assertEqual(200, response.status_code)
         self.assertEqual('test, omega: Ω, pile of poop: 💩', response.content)
 
-    def test_validate_ssl_certificate_success(self):
-        self.request_mock.url = 'https://api.twilio.com:8443'
-        response = self.client.request('doesnt-matter', 'doesnt-matter')
-        self.assertEqual(200, response.status_code)
+    @patch('twilio.http.validation_client')
+    def test_validate_ssl_certificate_success(self, http_client):
+        http_client.request.return_value = Response(200, 'success')
+        self.client.validate_ssl_certificate(http_client)
 
-    def test_validate_ssl_certificate_error(self):
-        self.session_mock.send.side_effect = TwilioRestException(500, 'https://api.twilio.com:8443', 'Error')
+    @patch('twilio.http.validation_client')
+    def test_validate_ssl_certificate_error(self, http_client):
+        http_client.request.return_value = Response(504, 'error')
 
         with self.assertRaises(TwilioRestException):
-            self.request_mock.url = 'https://api.twilio.com:8443'
-            self.client.request('doesnt-matter', 'doesnt-matter')
+            self.client.validate_ssl_certificate(http_client)

--- a/twilio/http/validation_client.py
+++ b/twilio/http/validation_client.py
@@ -96,7 +96,7 @@ class ValidationClient(HttpClient):
         parsed = urlparse(request.url)
         return parsed.netloc
 
-    def validateSslCertificate():
+    def validate_ssl_certificate():
         """
         Validate that a request to the new SSL certificate is successful
         :return: null on success, raise TwilioRestException if the request fails
@@ -105,4 +105,4 @@ class ValidationClient(HttpClient):
         try:
             response = client.request('GET', 'https://api.twilio.com:8443')
         except Exception:
-            raise TwilioRestException(500, 'https://api.twilio.com:8443', 'Failed to validate SSL certificate' + str(response))
+            raise TwilioRestException(500, 'https://api.twilio.com:8443', 'Failed to validate SSL certificate ' + str(response))

--- a/twilio/http/validation_client.py
+++ b/twilio/http/validation_client.py
@@ -5,7 +5,6 @@ from requests import Request, Session
 from twilio.base.exceptions import TwilioRestException
 from twilio.compat import urlparse
 from twilio.http import HttpClient
-from twilio.http.http_client import TwilioHttpClient
 from twilio.http.response import Response
 from twilio.jwt.validation import ClientValidationJwt
 
@@ -96,13 +95,12 @@ class ValidationClient(HttpClient):
         parsed = urlparse(request.url)
         return parsed.netloc
 
-    def validate_ssl_certificate():
+    def validate_ssl_certificate(self, client):
         """
         Validate that a request to the new SSL certificate is successful
         :return: null on success, raise TwilioRestException if the request fails
         """
-        client = TwilioHttpClient()
-        try:
-            response = client.request('GET', 'https://api.twilio.com:8443')
-        except Exception:
-            raise TwilioRestException(500, 'https://api.twilio.com:8443', 'Failed to validate SSL certificate ' + str(response))
+        response = client.request('GET', 'https://api.twilio.com:8443')
+
+        if response.status_code < 200 or response.status_code >= 300:
+            raise TwilioRestException(response.status_code, 'https://api.twilio.com:8443', 'Failed to validate SSL certificate')

--- a/twilio/http/validation_client.py
+++ b/twilio/http/validation_client.py
@@ -2,8 +2,10 @@ from collections import namedtuple
 
 from requests import Request, Session
 
+from twilio.base.exceptions import TwilioRestException
 from twilio.compat import urlparse
 from twilio.http import HttpClient
+from twilio.http.http_client import TwilioHttpClient
 from twilio.http.response import Response
 from twilio.jwt.validation import ClientValidationJwt
 
@@ -93,3 +95,14 @@ class ValidationClient(HttpClient):
         """Pull the Host out of the request"""
         parsed = urlparse(request.url)
         return parsed.netloc
+
+    def validateSslCertificate():
+        """
+        Validate that a request to the new SSL certificate is successful
+        :return: null on success, raise TwilioRestException if the request fails
+        """
+        client = TwilioHttpClient()
+        try:
+            response = client.request('GET', 'https://api.twilio.com:8443')
+        except Exception:
+            raise TwilioRestException(500, 'https://api.twilio.com:8443', 'Failed to validate SSL certificate' + str(response))


### PR DESCRIPTION
Add `validate_ssl_certificate` to check whether we can successfully make requests to the endpoint that uses the new SSL certificate