### PR TITLE
Add Dockerfile and related changes to build the Docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,8 @@ install:
   - make test-install
 script:
   - make test
+deploy:
+  script:
+    - make docker-build
+    - make docker-push
+  on: tags

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.6
+
+ENV PYTHONUNBUFFERED 1
+
+RUN mkdir -p /twilio/twilio
+WORKDIR /twilio
+
+COPY setup.py .
+COPY requirements.txt .
+COPY README.rst .
+COPY twilio/ twilio/
+
+RUN pip install .

--- a/Makefile
+++ b/Makefile
@@ -45,3 +45,14 @@ clean:
 
 nopyc:
 	find . -name \*.pyc -delete
+
+API_DEFINITIONS_SHA=$(shell git log --oneline | grep Regenerated | head -n1 | cut -d ' ' -f 5)
+docker-build:
+	docker build -t twilio/twilio-python .
+	docker tag twilio/twilio-python twilio/twilio-python:${TRAVIS_TAG}
+	docker tag twilio/twilio-python twilio/twilio-python:${API_DEFINITIONS_SHA}
+
+docker-push:
+	docker login -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD}
+	docker push twilio/twilio-python:${TRAVIS_TAG}
+	docker push twilio/twilio-python:${API_DEFINITIONS_TAG}


### PR DESCRIPTION
Hi there!

This PR adds the Dockerfile and related files to build the lib Docker image. This image will be used mainly by Tricorder to generate further Tricorder worker images with the specific lib version.

The tags used in the Docker images are the version (from the release tag) and the api-definitions SHA from the release.

TODO:
- [ ] Add Docker Hub credentials to the TravisCI env
- [ ] Merge and create a release for testing