### PR TITLE
Tag and push Docker latest image when deploying with TravisCI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,10 @@ docker-build:
 	docker build -t twilio/twilio-python .
 	docker tag twilio/twilio-python twilio/twilio-python:${TRAVIS_TAG}
 	docker tag twilio/twilio-python twilio/twilio-python:apidefs-${API_DEFINITIONS_SHA}
+	docker tag twilio/twilio-python twilio/twilio-python:latest
 
 docker-push:
 	echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
 	docker push twilio/twilio-python:${TRAVIS_TAG}
 	docker push twilio/twilio-python:apidefs-${API_DEFINITIONS_SHA}
+	docker push twilio/twilio-python:latest


### PR DESCRIPTION
Necessary image tag to be used with Tricorder.