### PR TITLE
Switch body validator to use hex instead of base64

### DIFF
--- a/tests/unit/test_request_validator.py
+++ b/tests/unit/test_request_validator.py
@@ -42,13 +42,13 @@ class ValidationTest(unittest.TestCase):
 
     def test_compute_hash_bytecode(self):
         expected = b(self.bodyHash)
-        body_hash = self.validator.compute_hash(self.body, utf=False)
+        body_hash = self.validator.compute_hash(self.body)
 
         assert_equal(expected, body_hash)
 
     def test_compute_hash_unicode(self):
         expected = u(self.bodyHash)
-        body_hash = self.validator.compute_hash(self.body, utf=True)
+        body_hash = self.validator.compute_hash(self.body)
 
         assert_equal(expected, body_hash)
 

--- a/tests/unit/test_request_validator.py
+++ b/tests/unit/test_request_validator.py
@@ -23,9 +23,8 @@ class ValidationTest(unittest.TestCase):
         }
         self.expected = "RSOYDt4T1cUTdK1PDd93/VVr8B8="
         self.body = "{\"property\": \"value\", \"boolean\": true}"
-        self.bodyHash = "Ch/3Y02as7ldtcmi3+lBbkFQKyg6gMfPGWMmMvluZiA="
-        self.encodedBodyHash = self.bodyHash.replace("+", "%2B").replace("=", "%3D")
-        self.uriWithBody = self.uri + "&bodySHA256=" + self.encodedBodyHash
+        self.bodyHash = "0a1ff7634d9ab3b95db5c9a2dfe9416e41502b283a80c7cf19632632f96e6620"
+        self.uriWithBody = self.uri + "&bodySHA256=" + self.bodyHash
 
     def test_compute_signature_bytecode(self):
         expected = b(self.expected)
@@ -62,5 +61,5 @@ class ValidationTest(unittest.TestCase):
 
     def test_validation_of_body_succeeds(self):
         uri = self.uriWithBody
-        is_valid = self.validator.validate(uri, self.body, "afcFvPLPYT8mg/JyIVkdnqQKa2s=")
+        is_valid = self.validator.validate(uri, self.body, "a9nBmqA0ju/hNViExpshrM61xv4=")
         assert_true(is_valid)

--- a/tests/unit/test_request_validator.py
+++ b/tests/unit/test_request_validator.py
@@ -33,18 +33,12 @@ class ValidationTest(unittest.TestCase):
                                                      utf=False)
         assert_equal(signature, expected)
 
-    def test_compute_signature_unicode(self):
-        expected = u(self.expected)
+    def test_compute_signature(self):
+        expected = (self.expected)
         signature = self.validator.compute_signature(self.uri,
                                                      self.params,
                                                      utf=True)
         assert_equal(signature, expected)
-
-    def test_compute_hash_bytecode(self):
-        expected = b(self.bodyHash)
-        body_hash = self.validator.compute_hash(self.body)
-
-        assert_equal(expected, body_hash)
 
     def test_compute_hash_unicode(self):
         expected = u(self.bodyHash)

--- a/twilio/request_validator.py
+++ b/twilio/request_validator.py
@@ -65,7 +65,7 @@ class RequestValidator(object):
         return computed.strip()
 
     def compute_hash(self, body, utf=PY3):
-        computed = base64.b64encode(sha256(body.encode("utf-8")).digest())
+        computed = sha256(body.encode("utf-8")).hexdigest()
 
         if utf:
             computed = computed.decode('utf-8')

--- a/twilio/request_validator.py
+++ b/twilio/request_validator.py
@@ -64,11 +64,8 @@ class RequestValidator(object):
 
         return computed.strip()
 
-    def compute_hash(self, body, utf=PY3):
+    def compute_hash(self, body):
         computed = sha256(body.encode("utf-8")).hexdigest()
-
-        if utf:
-            computed = computed.decode('utf-8')
 
         return computed.strip()
 


### PR DESCRIPTION
Our internal system sends the bodySHA256 parameter as hex, not base64, so this PR fixes that.