### PR TITLE
Prepend the repo root to the system paths during doc generation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,8 +15,7 @@
 #
 import os
 import sys
-sys.path.insert(0, os.path.join(os.path.abspath('..'), 'twilio'))
-sys.path.append('..')
+sys.path.insert(0, os.path.abspath('..'))
 from twilio import __version__
 
 


### PR DESCRIPTION
Docs were being generated using the current installed version of the lib instead of source path.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
