### PR TITLE
Use PyJWT version >= 1.4.2 in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ nose
 six
 requests>=2.0.0
 socksipy-branch
-PyJWT==1.4.2
+PyJWT>=1.4.2
 twine


### PR DESCRIPTION
<!-- Describe your Pull Request -->
`requirements.txt` currently uses 1.4.2 as fixed version.
The [setup.py](https://github.com/twilio/twilio-python/blob/c3b38d8ba4db483422c1bd575ce28f7eb6311b33/setup.py#L30) file uses PyJWT >= 1.4.2

It doesn't effect most of the part since, almost all the targets of Makefile
that require installing, do so using `pip install .`
However, docs-install target uses requirements directly but this change
shouldn't break anything in docs.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
