### PR TITLE
Change typehint for `PhoneNumberInstance.carrier`

### DIFF
--- a/twilio/rest/lookups/v1/phone_number.py
+++ b/twilio/rest/lookups/v1/phone_number.py
@@ -241,7 +241,7 @@ class PhoneNumberInstance(InstanceResource):
     def carrier(self):
         """
         :returns: The telecom company that provides the phone number
-        :rtype: unicode
+        :rtype: dict
         """
         return self._properties['carrier']
 


### PR DESCRIPTION
This PR closes #451, where the typehint for `PhoneNumberInstance.carrier` was wrong.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
