### PR TITLE
Adding timeout to TwilioHttpClient constructor

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -38,3 +38,4 @@ We'd like to thank the following people who have contributed to the
 - Evan Cooke
 - tysonholub
 - Brodan
+- Kyle Jones <kylejones1310@outlook.com>

--- a/tests/unit/http/test_http_client.py
+++ b/tests/unit/http/test_http_client.py
@@ -53,14 +53,14 @@ class TestHttpClientRequest(unittest.TestCase):
         self.assertEqual(200, response.status_code)
         self.assertEqual('testing-unicode: Ω≈ç√, 💩', response.content)
 
-    def test_request_where_timeout_equals_zero(self):
+    def test_request_where_method_timeout_equals_zero(self):
         self.request_mock.url = 'https://api.twilio.com/'
         self.request_mock.headers = {'Host': 'other.twilio.com'}
 
         try:
-            response = self.client.request(
+            self.client.request(
                 'doesnt matter', 'doesnt matter', None, None, None, None, 0, None)
-        except Exception as e:
+        except ValueError as e:
             self.assertEqual(ValueError, type(e))
 
     def test_request_where_class_timeout_manually_set(self):
@@ -80,19 +80,8 @@ class TestHttpClientRequest(unittest.TestCase):
         self.client.timeout = 0
 
         try:
-            response = self.client.request(
+            self.client.request(
                 'doesnt matter', 'doesnt matter')
-        except ValueError as e:
-            self.assertEqual(type(e), ValueError)
-
-    def test_request_where_method_timeout_equals_zero(self):
-        self.request_mock.url = 'https://api.twilio.com/'
-        self.request_mock.headers = {'Host': 'other.twilio.com'}
-        self.client.timeout = 30
-
-        try:
-            response = self.client.request(
-                'doesnt matter', 'doesnt matter', None, None, None, None, 0, None)
         except ValueError as e:
             self.assertEqual(type(e), ValueError)
 

--- a/tests/unit/http/test_http_client.py
+++ b/tests/unit/http/test_http_client.py
@@ -1,13 +1,10 @@
 # -*- coding: utf-8 -*-
-
 import six
 
 import unittest
 
-import mock
 from mock import patch, Mock
-from requests import Request
-from requests import Session
+from requests import Request, Session
 
 from twilio.http.http_client import TwilioHttpClient
 from twilio.http.response import Response
@@ -60,7 +57,7 @@ class TestHttpClientRequest(unittest.TestCase):
         try:
             self.client.request(
                 'doesnt matter', 'doesnt matter', None, None, None, None, 0, None)
-        except ValueError as e:
+        except Exception as e:
             self.assertEqual(ValueError, type(e))
 
     def test_request_where_class_timeout_manually_set(self):
@@ -82,7 +79,7 @@ class TestHttpClientRequest(unittest.TestCase):
         try:
             self.client.request(
                 'doesnt matter', 'doesnt matter')
-        except ValueError as e:
+        except Exception as e:
             self.assertEqual(type(e), ValueError)
 
     def test_request_where_class_timeout_and_method_timeout_set(self):

--- a/tests/unit/http/test_http_client.py
+++ b/tests/unit/http/test_http_client.py
@@ -42,6 +42,72 @@ class TestHttpClientRequest(unittest.TestCase):
         self.assertIsNotNone(self.client.last_request)
         self.assertIsNotNone(self.client.last_response)
 
+    def test_request_with_timeout(self):
+        self.request_mock.url = 'https://api.twilio.com/'
+        self.request_mock.headers = {'Host': 'other.twilio.com'}
+
+        response = self.client.request(
+            'doesnt matter', 'doesnt matter', None, None, None, None, 30, None)
+
+        self.assertEqual('other.twilio.com', self.request_mock.headers['Host'])
+        self.assertEqual(200, response.status_code)
+        self.assertEqual('testing-unicode: Ω≈ç√, 💩', response.content)
+
+    def test_request_where_timeout_equals_zero(self):
+        self.request_mock.url = 'https://api.twilio.com/'
+        self.request_mock.headers = {'Host': 'other.twilio.com'}
+
+        try:
+            response = self.client.request(
+                'doesnt matter', 'doesnt matter', None, None, None, None, 0, None)
+        except Exception as e:
+            self.assertEqual(ValueError, type(e))
+
+    def test_request_where_class_timeout_manually_set(self):
+        self.request_mock.url = 'https://api.twilio.com/'
+        self.request_mock.headers = {'Host': 'other.twilio.com'}
+        self.client.timeout = 30
+
+        response = self.client.request(
+                'doesnt matter', 'doesnt matter')
+        self.assertEqual('other.twilio.com', self.request_mock.headers['Host'])
+        self.assertEqual(200, response.status_code)
+        self.assertEqual('testing-unicode: Ω≈ç√, 💩', response.content)
+
+    def test_request_where_class_timeout_equals_zero(self):
+        self.request_mock.url = 'https://api.twilio.com/'
+        self.request_mock.headers = {'Host': 'other.twilio.com'}
+        self.client.timeout = 0
+
+        try:
+            response = self.client.request(
+                'doesnt matter', 'doesnt matter')
+        except ValueError as e:
+            self.assertEqual(type(e), ValueError)
+
+    def test_request_where_method_timeout_equals_zero(self):
+        self.request_mock.url = 'https://api.twilio.com/'
+        self.request_mock.headers = {'Host': 'other.twilio.com'}
+        self.client.timeout = 30
+
+        try:
+            response = self.client.request(
+                'doesnt matter', 'doesnt matter', None, None, None, None, 0, None)
+        except ValueError as e:
+            self.assertEqual(type(e), ValueError)
+
+    def test_request_where_class_timeout_and_method_timeout_set(self):
+        self.request_mock.url = 'https://api.twilio.com/'
+        self.request_mock.headers = {'Host': 'other.twilio.com'}
+        self.client.timeout = 30
+
+        response = self.client.request(
+            'doesnt matter', 'doesnt matter', None, None, None, None, 15, None)
+
+        self.assertEqual('other.twilio.com', self.request_mock.headers['Host'])
+        self.assertEqual(200, response.status_code)
+        self.assertEqual('testing-unicode: Ω≈ç√, 💩', response.content)
+
     def test_request_with_unicode_response(self):
         self.request_mock.url = 'https://api.twilio.com/'
         self.request_mock.headers = {'Host': 'other.twilio.com'}

--- a/twilio/http/http_client.py
+++ b/twilio/http/http_client.py
@@ -13,11 +13,12 @@ class TwilioHttpClient(HttpClient):
     """
     General purpose HTTP Client for interacting with the Twilio API
     """
-    def __init__(self, pool_connections=True, request_hooks=None):
+    def __init__(self, pool_connections=True, request_hooks=None, timeout=None):
         self.session = Session() if pool_connections else None
         self.last_request = None
         self.last_response = None
         self.request_hooks = request_hooks or hooks.default_hooks()
+        self.timeout = timeout
 
     def request(self, method, url, params=None, data=None, headers=None, auth=None, timeout=None,
                 allow_redirects=False):
@@ -65,7 +66,7 @@ class TwilioHttpClient(HttpClient):
         response = session.send(
             prepped_request,
             allow_redirects=allow_redirects,
-            timeout=timeout,
+            timeout=timeout if timeout is not None else self.timeout,
         )
 
         _logger.info('{method} Response: {status} {text}'.format(method=method, status=response.status_code, text=response.text))

--- a/twilio/http/http_client.py
+++ b/twilio/http/http_client.py
@@ -14,10 +14,23 @@ class TwilioHttpClient(HttpClient):
     General purpose HTTP Client for interacting with the Twilio API
     """
     def __init__(self, pool_connections=True, request_hooks=None, timeout=None):
+        """
+        Constructor for the TwilioHttpClient
+
+        :param bool pool_connections
+        :param request_hooks
+        :param int timeout: Timeout for the requests.
+                            Timeout should never be zero (0) or less.
+        """
         self.session = Session() if pool_connections else None
         self.last_request = None
         self.last_response = None
         self.request_hooks = request_hooks or hooks.default_hooks()
+
+        if timeout is None:
+            pass
+        elif timeout <= 0:
+            raise ValueError(timeout)
         self.timeout = timeout
 
     def request(self, method, url, params=None, data=None, headers=None, auth=None, timeout=None,
@@ -38,6 +51,10 @@ class TwilioHttpClient(HttpClient):
         :return: An http response
         :rtype: A :class:`Response <twilio.rest.http.response.Response>` object
         """
+        if timeout is None:
+            pass
+        elif timeout <= 0:
+            raise ValueError(timeout)
 
         kwargs = {
             'method': method.upper(),

--- a/twilio/http/http_client.py
+++ b/twilio/http/http_client.py
@@ -27,9 +27,7 @@ class TwilioHttpClient(HttpClient):
         self.last_response = None
         self.request_hooks = request_hooks or hooks.default_hooks()
 
-        if timeout is None:
-            pass
-        elif timeout <= 0:
+        if timeout is not None and timeout <= 0:
             raise ValueError(timeout)
         self.timeout = timeout
 
@@ -51,9 +49,7 @@ class TwilioHttpClient(HttpClient):
         :return: An http response
         :rtype: A :class:`Response <twilio.rest.http.response.Response>` object
         """
-        if timeout is None:
-            pass
-        elif timeout <= 0:
+        if timeout is not None and timeout <= 0:
             raise ValueError(timeout)
 
         kwargs = {


### PR DESCRIPTION
Fixes #460 - Adds a timeout parameter to the TwilioHttpClient constructor which is defaulted to None

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
