### PR TITLE
Declare support for Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
+  - "3.8"
 services:
   - docker
 install:

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,8 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Topic :: Communications :: Telephony",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
-envlist = py27, py33, py34, py35, py36, pypy
+envlist = py27, py3{4,5,6,7,8}, pypy
+skip_missing_interpreters = true
 
 [testenv]
 deps= -r{toxinidir}/tests/requirements.txt


### PR DESCRIPTION
Python 3.8 is there, so I believe that it would be nice to declare support and add tests for it on CI.

Python 3.8.0 release announcement:
https://discuss.python.org/t/python-3-8-0-is-now-available/2478

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
