### PR TITLE
fix: Change ObsoleteException to inherit from Exception instead of BaseException

### DIFF
--- a/twilio/base/obsolete.py
+++ b/twilio/base/obsolete.py
@@ -2,7 +2,7 @@ import warnings
 import functools
 
 
-class ObsoleteException(BaseException):
+class ObsoleteException(Exception):
     """ Base class for warnings about obsolete features. """
     pass
 


### PR DESCRIPTION
Related to #426 - Do not inherit from `BaseException`

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
