### PR TITLE
feat: support http proxy in TwilioHttpClient

### DIFF
--- a/tests/unit/http/test_http_client.py
+++ b/tests/unit/http/test_http_client.py
@@ -134,6 +134,15 @@ class TestHttpClientRequest(unittest.TestCase):
             self.assertIsNotNone(self.client.last_request)
             self.assertIsNone(self.client.last_response)
 
+    def test_request_behind_proxy(self):
+        proxies = {
+            'http': 'http://proxy.twilio.com',
+            'https': 'https://proxy.twilio.com',
+        }
+        self.client = TwilioHttpClient(proxy=proxies)
+        self.client.request('doesnt matter', 'doesnt matter')
+        self.assertEqual(self.client.proxy, self.session_mock.proxies)
+
 
 class TestHttpClientSession(unittest.TestCase):
 

--- a/tests/unit/http/test_http_client.py
+++ b/tests/unit/http/test_http_client.py
@@ -141,7 +141,7 @@ class TestHttpClientRequest(unittest.TestCase):
         }
         self.client = TwilioHttpClient(proxy=proxies)
         self.client.request('doesnt matter', 'doesnt matter')
-        self.assertEqual(self.client.proxy, self.session_mock.proxies)
+        self.assertEqual(proxies, self.session_mock.proxies)
 
 
 class TestHttpClientSession(unittest.TestCase):

--- a/twilio/http/http_client.py
+++ b/twilio/http/http_client.py
@@ -13,7 +13,7 @@ class TwilioHttpClient(HttpClient):
     """
     General purpose HTTP Client for interacting with the Twilio API
     """
-    def __init__(self, pool_connections=True, request_hooks=None, timeout=None, logger=_logger):
+    def __init__(self, pool_connections=True, request_hooks=None, timeout=None, logger=_logger, proxy=None):
         """
         Constructor for the TwilioHttpClient
 
@@ -22,6 +22,7 @@ class TwilioHttpClient(HttpClient):
         :param int timeout: Timeout for the requests.
                             Timeout should never be zero (0) or less.
         :param logger
+        :param dict proxy: Http proxy for the requests session
         """
         self.session = Session() if pool_connections else None
         self.last_request = None
@@ -32,6 +33,7 @@ class TwilioHttpClient(HttpClient):
         if timeout is not None and timeout <= 0:
             raise ValueError(timeout)
         self.timeout = timeout
+        self.proxy = proxy
 
     def request(self, method, url, params=None, data=None, headers=None, auth=None, timeout=None,
                 allow_redirects=False):
@@ -74,6 +76,8 @@ class TwilioHttpClient(HttpClient):
 
         self.last_response = None
         session = self.session or Session()
+        if self.proxy:
+            session.proxies = self.proxy
         request = Request(**kwargs)
         self.last_request = TwilioRequest(**kwargs)
 


### PR DESCRIPTION
Ref https://github.com/twilio/twilio-python/issues/409

Adding support for TwilioHttpClient to make requests behind a custom proxy, for example

``` python
from twilio.http.http_client import TwilioHttpClient
from twilio.rest import Client

sid = ''
token = ''
http_client = TwilioHttpClient(proxy={'http': 'http://proxy.twilio.com:8118'})
twilio_client = Client(sid, token, http_client=http_client)
twilio_client.messages.create()
```

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
