### PR TITLE
feat: add new max_retries param to TwilioHttpClient

### DIFF
--- a/twilio/http/http_client.py
+++ b/twilio/http/http_client.py
@@ -1,4 +1,5 @@
 from requests import Request, Session, hooks
+from requests.adapters import HTTPAdapter
 
 from twilio.http import HttpClient
 from twilio.http.response import Response
@@ -13,7 +14,7 @@ class TwilioHttpClient(HttpClient):
     """
     General purpose HTTP Client for interacting with the Twilio API
     """
-    def __init__(self, pool_connections=True, request_hooks=None, timeout=None, logger=_logger, proxy=None):
+    def __init__(self, pool_connections=True, request_hooks=None, timeout=None, logger=_logger, proxy=None, max_retries=3):
         """
         Constructor for the TwilioHttpClient
 
@@ -23,8 +24,11 @@ class TwilioHttpClient(HttpClient):
                             Timeout should never be zero (0) or less.
         :param logger
         :param dict proxy: Http proxy for the requests session
+        :param int max_retries: Maximum number of retries each request should attempt
         """
         self.session = Session() if pool_connections else None
+        if self.session:
+            self.session.mount('https://', HTTPAdapter(max_retries=max_retries))
         self.last_request = None
         self.last_response = None
         self.logger = logger

--- a/twilio/http/http_client.py
+++ b/twilio/http/http_client.py
@@ -14,7 +14,7 @@ class TwilioHttpClient(HttpClient):
     """
     General purpose HTTP Client for interacting with the Twilio API
     """
-    def __init__(self, pool_connections=True, request_hooks=None, timeout=None, logger=_logger, proxy=None, max_retries=3):
+    def __init__(self, pool_connections=True, request_hooks=None, timeout=None, logger=_logger, proxy=None, max_retries=None):
         """
         Constructor for the TwilioHttpClient
 
@@ -27,7 +27,7 @@ class TwilioHttpClient(HttpClient):
         :param int max_retries: Maximum number of retries each request should attempt
         """
         self.session = Session() if pool_connections else None
-        if self.session:
+        if self.session and max_retries is not None:
             self.session.mount('https://', HTTPAdapter(max_retries=max_retries))
         self.last_request = None
         self.last_response = None


### PR DESCRIPTION
# Fixes #506

Fixes the #506 issue by retrying the failed connection.

I've seen something similar implemented in the Java version: https://github.com/twilio/twilio-java/blob/master/src/main/java/com/twilio/http/HttpClient.java

### Checklist
- [X] I acknowledge that all my contributions will be made under the project's license
- [X] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [X] I have read the [Contribution Guidelines](CONTRIBUTING.md) and my PR follows them
- [X] I have titled the PR appropriately
- [X] I have updated my branch with the master branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [X] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
