### PR TITLE
fix: drop passing a page limit when listing/streaming resources

### DIFF
--- a/twilio/rest/accounts/v1/credential/aws.py
+++ b/twilio/rest/accounts/v1/credential/aws.py
@@ -53,7 +53,7 @@ class AwsList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/accounts/v1/credential/public_key.py
+++ b/twilio/rest/accounts/v1/credential/public_key.py
@@ -53,7 +53,7 @@ class PublicKeyList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/api/v2010/account/__init__.py
+++ b/twilio/rest/api/v2010/account/__init__.py
@@ -95,7 +95,7 @@ class AccountList(ListResource):
 
         page = self.page(friendly_name=friendly_name, status=status, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, friendly_name=values.unset, status=values.unset, limit=None,
              page_size=None):

--- a/twilio/rest/api/v2010/account/address/__init__.py
+++ b/twilio/rest/api/v2010/account/address/__init__.py
@@ -99,7 +99,7 @@ class AddressList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, customer_name=values.unset, friendly_name=values.unset,
              iso_country=values.unset, limit=None, page_size=None):

--- a/twilio/rest/api/v2010/account/address/dependent_phone_number.py
+++ b/twilio/rest/api/v2010/account/address/dependent_phone_number.py
@@ -54,7 +54,7 @@ class DependentPhoneNumberList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/api/v2010/account/application.py
+++ b/twilio/rest/api/v2010/account/application.py
@@ -107,7 +107,7 @@ class ApplicationList(ListResource):
 
         page = self.page(friendly_name=friendly_name, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, friendly_name=values.unset, limit=None, page_size=None):
         """

--- a/twilio/rest/api/v2010/account/authorized_connect_app.py
+++ b/twilio/rest/api/v2010/account/authorized_connect_app.py
@@ -54,7 +54,7 @@ class AuthorizedConnectAppList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/api/v2010/account/available_phone_number/__init__.py
+++ b/twilio/rest/api/v2010/account/available_phone_number/__init__.py
@@ -60,7 +60,7 @@ class AvailablePhoneNumberCountryList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/api/v2010/account/available_phone_number/local.py
+++ b/twilio/rest/api/v2010/account/available_phone_number/local.py
@@ -102,7 +102,7 @@ class LocalList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, area_code=values.unset, contains=values.unset,
              sms_enabled=values.unset, mms_enabled=values.unset,

--- a/twilio/rest/api/v2010/account/available_phone_number/machine_to_machine.py
+++ b/twilio/rest/api/v2010/account/available_phone_number/machine_to_machine.py
@@ -102,7 +102,7 @@ class MachineToMachineList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, area_code=values.unset, contains=values.unset,
              sms_enabled=values.unset, mms_enabled=values.unset,

--- a/twilio/rest/api/v2010/account/available_phone_number/mobile.py
+++ b/twilio/rest/api/v2010/account/available_phone_number/mobile.py
@@ -102,7 +102,7 @@ class MobileList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, area_code=values.unset, contains=values.unset,
              sms_enabled=values.unset, mms_enabled=values.unset,

--- a/twilio/rest/api/v2010/account/available_phone_number/national.py
+++ b/twilio/rest/api/v2010/account/available_phone_number/national.py
@@ -102,7 +102,7 @@ class NationalList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, area_code=values.unset, contains=values.unset,
              sms_enabled=values.unset, mms_enabled=values.unset,

--- a/twilio/rest/api/v2010/account/available_phone_number/shared_cost.py
+++ b/twilio/rest/api/v2010/account/available_phone_number/shared_cost.py
@@ -102,7 +102,7 @@ class SharedCostList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, area_code=values.unset, contains=values.unset,
              sms_enabled=values.unset, mms_enabled=values.unset,

--- a/twilio/rest/api/v2010/account/available_phone_number/toll_free.py
+++ b/twilio/rest/api/v2010/account/available_phone_number/toll_free.py
@@ -102,7 +102,7 @@ class TollFreeList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, area_code=values.unset, contains=values.unset,
              sms_enabled=values.unset, mms_enabled=values.unset,

--- a/twilio/rest/api/v2010/account/available_phone_number/voip.py
+++ b/twilio/rest/api/v2010/account/available_phone_number/voip.py
@@ -102,7 +102,7 @@ class VoipList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, area_code=values.unset, contains=values.unset,
              sms_enabled=values.unset, mms_enabled=values.unset,

--- a/twilio/rest/api/v2010/account/call/__init__.py
+++ b/twilio/rest/api/v2010/account/call/__init__.py
@@ -188,7 +188,7 @@ class CallList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, to=values.unset, from_=values.unset,
              parent_call_sid=values.unset, status=values.unset,

--- a/twilio/rest/api/v2010/account/call/notification.py
+++ b/twilio/rest/api/v2010/account/call/notification.py
@@ -68,7 +68,7 @@ class NotificationList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, log=values.unset, message_date_before=values.unset,
              message_date=values.unset, message_date_after=values.unset, limit=None,

--- a/twilio/rest/api/v2010/account/call/recording.py
+++ b/twilio/rest/api/v2010/account/call/recording.py
@@ -98,7 +98,7 @@ class RecordingList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, date_created_before=values.unset, date_created=values.unset,
              date_created_after=values.unset, limit=None, page_size=None):

--- a/twilio/rest/api/v2010/account/conference/__init__.py
+++ b/twilio/rest/api/v2010/account/conference/__init__.py
@@ -79,7 +79,7 @@ class ConferenceList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, date_created_before=values.unset, date_created=values.unset,
              date_created_after=values.unset, date_updated_before=values.unset,

--- a/twilio/rest/api/v2010/account/conference/participant.py
+++ b/twilio/rest/api/v2010/account/conference/participant.py
@@ -168,7 +168,7 @@ class ParticipantList(ListResource):
 
         page = self.page(muted=muted, hold=hold, coaching=coaching, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, muted=values.unset, hold=values.unset, coaching=values.unset,
              limit=None, page_size=None):

--- a/twilio/rest/api/v2010/account/conference/recording.py
+++ b/twilio/rest/api/v2010/account/conference/recording.py
@@ -65,7 +65,7 @@ class RecordingList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, date_created_before=values.unset, date_created=values.unset,
              date_created_after=values.unset, limit=None, page_size=None):

--- a/twilio/rest/api/v2010/account/connect_app.py
+++ b/twilio/rest/api/v2010/account/connect_app.py
@@ -54,7 +54,7 @@ class ConnectAppList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/api/v2010/account/incoming_phone_number/__init__.py
+++ b/twilio/rest/api/v2010/account/incoming_phone_number/__init__.py
@@ -75,7 +75,7 @@ class IncomingPhoneNumberList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, beta=values.unset, friendly_name=values.unset,
              phone_number=values.unset, origin=values.unset, limit=None,

--- a/twilio/rest/api/v2010/account/incoming_phone_number/assigned_add_on/__init__.py
+++ b/twilio/rest/api/v2010/account/incoming_phone_number/assigned_add_on/__init__.py
@@ -57,7 +57,7 @@ class AssignedAddOnList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/api/v2010/account/incoming_phone_number/assigned_add_on/assigned_add_on_extension.py
+++ b/twilio/rest/api/v2010/account/incoming_phone_number/assigned_add_on/assigned_add_on_extension.py
@@ -60,7 +60,7 @@ class AssignedAddOnExtensionList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/api/v2010/account/incoming_phone_number/local.py
+++ b/twilio/rest/api/v2010/account/incoming_phone_number/local.py
@@ -65,7 +65,7 @@ class LocalList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, beta=values.unset, friendly_name=values.unset,
              phone_number=values.unset, origin=values.unset, limit=None,

--- a/twilio/rest/api/v2010/account/incoming_phone_number/mobile.py
+++ b/twilio/rest/api/v2010/account/incoming_phone_number/mobile.py
@@ -65,7 +65,7 @@ class MobileList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, beta=values.unset, friendly_name=values.unset,
              phone_number=values.unset, origin=values.unset, limit=None,

--- a/twilio/rest/api/v2010/account/incoming_phone_number/toll_free.py
+++ b/twilio/rest/api/v2010/account/incoming_phone_number/toll_free.py
@@ -65,7 +65,7 @@ class TollFreeList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, beta=values.unset, friendly_name=values.unset,
              phone_number=values.unset, origin=values.unset, limit=None,

--- a/twilio/rest/api/v2010/account/key.py
+++ b/twilio/rest/api/v2010/account/key.py
@@ -54,7 +54,7 @@ class KeyList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/api/v2010/account/message/__init__.py
+++ b/twilio/rest/api/v2010/account/message/__init__.py
@@ -125,7 +125,7 @@ class MessageList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, to=values.unset, from_=values.unset,
              date_sent_before=values.unset, date_sent=values.unset,

--- a/twilio/rest/api/v2010/account/message/media.py
+++ b/twilio/rest/api/v2010/account/message/media.py
@@ -65,7 +65,7 @@ class MediaList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, date_created_before=values.unset, date_created=values.unset,
              date_created_after=values.unset, limit=None, page_size=None):

--- a/twilio/rest/api/v2010/account/notification.py
+++ b/twilio/rest/api/v2010/account/notification.py
@@ -67,7 +67,7 @@ class NotificationList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, log=values.unset, message_date_before=values.unset,
              message_date=values.unset, message_date_after=values.unset, limit=None,

--- a/twilio/rest/api/v2010/account/outgoing_caller_id.py
+++ b/twilio/rest/api/v2010/account/outgoing_caller_id.py
@@ -61,7 +61,7 @@ class OutgoingCallerIdList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, phone_number=values.unset, friendly_name=values.unset,
              limit=None, page_size=None):

--- a/twilio/rest/api/v2010/account/queue/__init__.py
+++ b/twilio/rest/api/v2010/account/queue/__init__.py
@@ -55,7 +55,7 @@ class QueueList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/api/v2010/account/queue/member.py
+++ b/twilio/rest/api/v2010/account/queue/member.py
@@ -55,7 +55,7 @@ class MemberList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/api/v2010/account/recording/__init__.py
+++ b/twilio/rest/api/v2010/account/recording/__init__.py
@@ -71,7 +71,7 @@ class RecordingList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, date_created_before=values.unset, date_created=values.unset,
              date_created_after=values.unset, call_sid=values.unset,

--- a/twilio/rest/api/v2010/account/recording/add_on_result/__init__.py
+++ b/twilio/rest/api/v2010/account/recording/add_on_result/__init__.py
@@ -56,7 +56,7 @@ class AddOnResultList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/api/v2010/account/recording/add_on_result/payload/__init__.py
+++ b/twilio/rest/api/v2010/account/recording/add_on_result/payload/__init__.py
@@ -60,7 +60,7 @@ class PayloadList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/api/v2010/account/recording/transcription.py
+++ b/twilio/rest/api/v2010/account/recording/transcription.py
@@ -55,7 +55,7 @@ class TranscriptionList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/api/v2010/account/short_code.py
+++ b/twilio/rest/api/v2010/account/short_code.py
@@ -57,7 +57,7 @@ class ShortCodeList(ListResource):
 
         page = self.page(friendly_name=friendly_name, short_code=short_code, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, friendly_name=values.unset, short_code=values.unset, limit=None,
              page_size=None):

--- a/twilio/rest/api/v2010/account/signing_key.py
+++ b/twilio/rest/api/v2010/account/signing_key.py
@@ -54,7 +54,7 @@ class SigningKeyList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/api/v2010/account/sip/credential_list/__init__.py
+++ b/twilio/rest/api/v2010/account/sip/credential_list/__init__.py
@@ -55,7 +55,7 @@ class CredentialListList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/api/v2010/account/sip/credential_list/credential.py
+++ b/twilio/rest/api/v2010/account/sip/credential_list/credential.py
@@ -55,7 +55,7 @@ class CredentialList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/api/v2010/account/sip/domain/__init__.py
+++ b/twilio/rest/api/v2010/account/sip/domain/__init__.py
@@ -57,7 +57,7 @@ class DomainList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/api/v2010/account/sip/domain/auth_types/auth_calls_mapping/auth_calls_credential_list_mapping.py
+++ b/twilio/rest/api/v2010/account/sip/domain/auth_types/auth_calls_mapping/auth_calls_credential_list_mapping.py
@@ -75,7 +75,7 @@ class AuthCallsCredentialListMappingList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/api/v2010/account/sip/domain/auth_types/auth_calls_mapping/auth_calls_ip_access_control_list_mapping.py
+++ b/twilio/rest/api/v2010/account/sip/domain/auth_types/auth_calls_mapping/auth_calls_ip_access_control_list_mapping.py
@@ -75,7 +75,7 @@ class AuthCallsIpAccessControlListMappingList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/api/v2010/account/sip/domain/auth_types/auth_registrations_mapping/auth_registrations_credential_list_mapping.py
+++ b/twilio/rest/api/v2010/account/sip/domain/auth_types/auth_registrations_mapping/auth_registrations_credential_list_mapping.py
@@ -75,7 +75,7 @@ class AuthRegistrationsCredentialListMappingList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/api/v2010/account/sip/domain/credential_list_mapping.py
+++ b/twilio/rest/api/v2010/account/sip/domain/credential_list_mapping.py
@@ -75,7 +75,7 @@ class CredentialListMappingList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/api/v2010/account/sip/domain/ip_access_control_list_mapping.py
+++ b/twilio/rest/api/v2010/account/sip/domain/ip_access_control_list_mapping.py
@@ -75,7 +75,7 @@ class IpAccessControlListMappingList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/api/v2010/account/sip/ip_access_control_list/__init__.py
+++ b/twilio/rest/api/v2010/account/sip/ip_access_control_list/__init__.py
@@ -55,7 +55,7 @@ class IpAccessControlListList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/api/v2010/account/sip/ip_access_control_list/ip_address.py
+++ b/twilio/rest/api/v2010/account/sip/ip_access_control_list/ip_address.py
@@ -58,7 +58,7 @@ class IpAddressList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/api/v2010/account/transcription.py
+++ b/twilio/rest/api/v2010/account/transcription.py
@@ -54,7 +54,7 @@ class TranscriptionList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/api/v2010/account/usage/record/__init__.py
+++ b/twilio/rest/api/v2010/account/usage/record/__init__.py
@@ -84,7 +84,7 @@ class RecordList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, category=values.unset, start_date=values.unset,
              end_date=values.unset, include_subaccounts=values.unset, limit=None,

--- a/twilio/rest/api/v2010/account/usage/record/all_time.py
+++ b/twilio/rest/api/v2010/account/usage/record/all_time.py
@@ -66,7 +66,7 @@ class AllTimeList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, category=values.unset, start_date=values.unset,
              end_date=values.unset, include_subaccounts=values.unset, limit=None,

--- a/twilio/rest/api/v2010/account/usage/record/daily.py
+++ b/twilio/rest/api/v2010/account/usage/record/daily.py
@@ -66,7 +66,7 @@ class DailyList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, category=values.unset, start_date=values.unset,
              end_date=values.unset, include_subaccounts=values.unset, limit=None,

--- a/twilio/rest/api/v2010/account/usage/record/last_month.py
+++ b/twilio/rest/api/v2010/account/usage/record/last_month.py
@@ -66,7 +66,7 @@ class LastMonthList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, category=values.unset, start_date=values.unset,
              end_date=values.unset, include_subaccounts=values.unset, limit=None,

--- a/twilio/rest/api/v2010/account/usage/record/monthly.py
+++ b/twilio/rest/api/v2010/account/usage/record/monthly.py
@@ -66,7 +66,7 @@ class MonthlyList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, category=values.unset, start_date=values.unset,
              end_date=values.unset, include_subaccounts=values.unset, limit=None,

--- a/twilio/rest/api/v2010/account/usage/record/this_month.py
+++ b/twilio/rest/api/v2010/account/usage/record/this_month.py
@@ -66,7 +66,7 @@ class ThisMonthList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, category=values.unset, start_date=values.unset,
              end_date=values.unset, include_subaccounts=values.unset, limit=None,

--- a/twilio/rest/api/v2010/account/usage/record/today.py
+++ b/twilio/rest/api/v2010/account/usage/record/today.py
@@ -66,7 +66,7 @@ class TodayList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, category=values.unset, start_date=values.unset,
              end_date=values.unset, include_subaccounts=values.unset, limit=None,

--- a/twilio/rest/api/v2010/account/usage/record/yearly.py
+++ b/twilio/rest/api/v2010/account/usage/record/yearly.py
@@ -66,7 +66,7 @@ class YearlyList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, category=values.unset, start_date=values.unset,
              end_date=values.unset, include_subaccounts=values.unset, limit=None,

--- a/twilio/rest/api/v2010/account/usage/record/yesterday.py
+++ b/twilio/rest/api/v2010/account/usage/record/yesterday.py
@@ -66,7 +66,7 @@ class YesterdayList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, category=values.unset, start_date=values.unset,
              end_date=values.unset, include_subaccounts=values.unset, limit=None,

--- a/twilio/rest/api/v2010/account/usage/trigger.py
+++ b/twilio/rest/api/v2010/account/usage/trigger.py
@@ -94,7 +94,7 @@ class TriggerList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, recurring=values.unset, trigger_by=values.unset,
              usage_category=values.unset, limit=None, page_size=None):

--- a/twilio/rest/authy/v1/service/__init__.py
+++ b/twilio/rest/authy/v1/service/__init__.py
@@ -76,7 +76,7 @@ class ServiceList(ListResource):
 
         page = self.page(twilio_sandbox_mode=twilio_sandbox_mode, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, twilio_sandbox_mode=values.unset, limit=None, page_size=None):
         """

--- a/twilio/rest/authy/v1/service/entity/__init__.py
+++ b/twilio/rest/authy/v1/service/entity/__init__.py
@@ -75,7 +75,7 @@ class EntityList(ListResource):
 
         page = self.page(twilio_sandbox_mode=twilio_sandbox_mode, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, twilio_sandbox_mode=values.unset, limit=None, page_size=None):
         """

--- a/twilio/rest/authy/v1/service/entity/factor/__init__.py
+++ b/twilio/rest/authy/v1/service/entity/factor/__init__.py
@@ -91,7 +91,7 @@ class FactorList(ListResource):
 
         page = self.page(twilio_sandbox_mode=twilio_sandbox_mode, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, twilio_sandbox_mode=values.unset, limit=None, page_size=None):
         """

--- a/twilio/rest/authy/v1/service/entity/factor/challenge.py
+++ b/twilio/rest/authy/v1/service/entity/factor/challenge.py
@@ -96,7 +96,7 @@ class ChallengeList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, status=values.unset, twilio_sandbox_mode=values.unset,
              limit=None, page_size=None):

--- a/twilio/rest/autopilot/v1/assistant/__init__.py
+++ b/twilio/rest/autopilot/v1/assistant/__init__.py
@@ -65,7 +65,7 @@ class AssistantList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/autopilot/v1/assistant/field_type/__init__.py
+++ b/twilio/rest/autopilot/v1/assistant/field_type/__init__.py
@@ -57,7 +57,7 @@ class FieldTypeList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/autopilot/v1/assistant/field_type/field_value.py
+++ b/twilio/rest/autopilot/v1/assistant/field_type/field_value.py
@@ -58,7 +58,7 @@ class FieldValueList(ListResource):
 
         page = self.page(language=language, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, language=values.unset, limit=None, page_size=None):
         """

--- a/twilio/rest/autopilot/v1/assistant/model_build.py
+++ b/twilio/rest/autopilot/v1/assistant/model_build.py
@@ -56,7 +56,7 @@ class ModelBuildList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/autopilot/v1/assistant/query.py
+++ b/twilio/rest/autopilot/v1/assistant/query.py
@@ -65,7 +65,7 @@ class QueryList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, language=values.unset, model_build=values.unset,
              status=values.unset, limit=None, page_size=None):

--- a/twilio/rest/autopilot/v1/assistant/task/__init__.py
+++ b/twilio/rest/autopilot/v1/assistant/task/__init__.py
@@ -61,7 +61,7 @@ class TaskList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/autopilot/v1/assistant/task/field.py
+++ b/twilio/rest/autopilot/v1/assistant/task/field.py
@@ -57,7 +57,7 @@ class FieldList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/autopilot/v1/assistant/task/sample.py
+++ b/twilio/rest/autopilot/v1/assistant/task/sample.py
@@ -58,7 +58,7 @@ class SampleList(ListResource):
 
         page = self.page(language=language, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, language=values.unset, limit=None, page_size=None):
         """

--- a/twilio/rest/autopilot/v1/assistant/webhook.py
+++ b/twilio/rest/autopilot/v1/assistant/webhook.py
@@ -56,7 +56,7 @@ class WebhookList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/bulkexports/v1/export/day.py
+++ b/twilio/rest/bulkexports/v1/export/day.py
@@ -62,7 +62,7 @@ class DayList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, next_token=values.unset, previous_token=values.unset, limit=None,
              page_size=None):

--- a/twilio/rest/bulkexports/v1/export/export_custom_job.py
+++ b/twilio/rest/bulkexports/v1/export/export_custom_job.py
@@ -60,7 +60,7 @@ class ExportCustomJobList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, next_token=values.unset, previous_token=values.unset, limit=None,
              page_size=None):

--- a/twilio/rest/chat/v1/credential.py
+++ b/twilio/rest/chat/v1/credential.py
@@ -53,7 +53,7 @@ class CredentialList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/chat/v1/service/__init__.py
+++ b/twilio/rest/chat/v1/service/__init__.py
@@ -72,7 +72,7 @@ class ServiceList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/chat/v1/service/channel/__init__.py
+++ b/twilio/rest/chat/v1/service/channel/__init__.py
@@ -83,7 +83,7 @@ class ChannelList(ListResource):
 
         page = self.page(type=type, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, type=values.unset, limit=None, page_size=None):
         """

--- a/twilio/rest/chat/v1/service/channel/invite.py
+++ b/twilio/rest/chat/v1/service/channel/invite.py
@@ -78,7 +78,7 @@ class InviteList(ListResource):
 
         page = self.page(identity=identity, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, identity=values.unset, limit=None, page_size=None):
         """

--- a/twilio/rest/chat/v1/service/channel/member.py
+++ b/twilio/rest/chat/v1/service/channel/member.py
@@ -78,7 +78,7 @@ class MemberList(ListResource):
 
         page = self.page(identity=identity, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, identity=values.unset, limit=None, page_size=None):
         """

--- a/twilio/rest/chat/v1/service/channel/message.py
+++ b/twilio/rest/chat/v1/service/channel/message.py
@@ -78,7 +78,7 @@ class MessageList(ListResource):
 
         page = self.page(order=order, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, order=values.unset, limit=None, page_size=None):
         """

--- a/twilio/rest/chat/v1/service/role.py
+++ b/twilio/rest/chat/v1/service/role.py
@@ -76,7 +76,7 @@ class RoleList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/chat/v1/service/user/__init__.py
+++ b/twilio/rest/chat/v1/service/user/__init__.py
@@ -79,7 +79,7 @@ class UserList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/chat/v1/service/user/user_channel.py
+++ b/twilio/rest/chat/v1/service/user/user_channel.py
@@ -54,7 +54,7 @@ class UserChannelList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/chat/v2/credential.py
+++ b/twilio/rest/chat/v2/credential.py
@@ -53,7 +53,7 @@ class CredentialList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/chat/v2/service/__init__.py
+++ b/twilio/rest/chat/v2/service/__init__.py
@@ -73,7 +73,7 @@ class ServiceList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/chat/v2/service/binding.py
+++ b/twilio/rest/chat/v2/service/binding.py
@@ -58,7 +58,7 @@ class BindingList(ListResource):
 
         page = self.page(binding_type=binding_type, identity=identity, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, binding_type=values.unset, identity=values.unset, limit=None,
              page_size=None):

--- a/twilio/rest/chat/v2/service/channel/__init__.py
+++ b/twilio/rest/chat/v2/service/channel/__init__.py
@@ -94,7 +94,7 @@ class ChannelList(ListResource):
 
         page = self.page(type=type, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, type=values.unset, limit=None, page_size=None):
         """

--- a/twilio/rest/chat/v2/service/channel/invite.py
+++ b/twilio/rest/chat/v2/service/channel/invite.py
@@ -78,7 +78,7 @@ class InviteList(ListResource):
 
         page = self.page(identity=identity, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, identity=values.unset, limit=None, page_size=None):
         """

--- a/twilio/rest/chat/v2/service/channel/member.py
+++ b/twilio/rest/chat/v2/service/channel/member.py
@@ -97,7 +97,7 @@ class MemberList(ListResource):
 
         page = self.page(identity=identity, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, identity=values.unset, limit=None, page_size=None):
         """

--- a/twilio/rest/chat/v2/service/channel/message.py
+++ b/twilio/rest/chat/v2/service/channel/message.py
@@ -96,7 +96,7 @@ class MessageList(ListResource):
 
         page = self.page(order=order, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, order=values.unset, limit=None, page_size=None):
         """

--- a/twilio/rest/chat/v2/service/channel/webhook.py
+++ b/twilio/rest/chat/v2/service/channel/webhook.py
@@ -56,7 +56,7 @@ class WebhookList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/chat/v2/service/role.py
+++ b/twilio/rest/chat/v2/service/role.py
@@ -76,7 +76,7 @@ class RoleList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/chat/v2/service/user/__init__.py
+++ b/twilio/rest/chat/v2/service/user/__init__.py
@@ -82,7 +82,7 @@ class UserList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/chat/v2/service/user/user_binding.py
+++ b/twilio/rest/chat/v2/service/user/user_binding.py
@@ -57,7 +57,7 @@ class UserBindingList(ListResource):
 
         page = self.page(binding_type=binding_type, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, binding_type=values.unset, limit=None, page_size=None):
         """

--- a/twilio/rest/chat/v2/service/user/user_channel.py
+++ b/twilio/rest/chat/v2/service/user/user_channel.py
@@ -56,7 +56,7 @@ class UserChannelList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/conversations/v1/conversation/__init__.py
+++ b/twilio/rest/conversations/v1/conversation/__init__.py
@@ -90,7 +90,7 @@ class ConversationList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/conversations/v1/conversation/message.py
+++ b/twilio/rest/conversations/v1/conversation/message.py
@@ -88,7 +88,7 @@ class MessageList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/conversations/v1/conversation/participant.py
+++ b/twilio/rest/conversations/v1/conversation/participant.py
@@ -98,7 +98,7 @@ class ParticipantList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/conversations/v1/conversation/webhook.py
+++ b/twilio/rest/conversations/v1/conversation/webhook.py
@@ -56,7 +56,7 @@ class WebhookList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/fax/v1/fax/__init__.py
+++ b/twilio/rest/fax/v1/fax/__init__.py
@@ -68,7 +68,7 @@ class FaxList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, from_=values.unset, to=values.unset,
              date_created_on_or_before=values.unset,

--- a/twilio/rest/fax/v1/fax/fax_media.py
+++ b/twilio/rest/fax/v1/fax/fax_media.py
@@ -55,7 +55,7 @@ class FaxMediaList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/flex_api/v1/channel.py
+++ b/twilio/rest/flex_api/v1/channel.py
@@ -53,7 +53,7 @@ class ChannelList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/flex_api/v1/flex_flow.py
+++ b/twilio/rest/flex_api/v1/flex_flow.py
@@ -54,7 +54,7 @@ class FlexFlowList(ListResource):
 
         page = self.page(friendly_name=friendly_name, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, friendly_name=values.unset, limit=None, page_size=None):
         """

--- a/twilio/rest/flex_api/v1/web_channel.py
+++ b/twilio/rest/flex_api/v1/web_channel.py
@@ -53,7 +53,7 @@ class WebChannelList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/insights/v1/call/event.py
+++ b/twilio/rest/insights/v1/call/event.py
@@ -55,7 +55,7 @@ class EventList(ListResource):
 
         page = self.page(edge=edge, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, edge=values.unset, limit=None, page_size=None):
         """

--- a/twilio/rest/insights/v1/call/metric.py
+++ b/twilio/rest/insights/v1/call/metric.py
@@ -57,7 +57,7 @@ class MetricList(ListResource):
 
         page = self.page(edge=edge, direction=direction, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, edge=values.unset, direction=values.unset, limit=None,
              page_size=None):

--- a/twilio/rest/ip_messaging/v1/credential.py
+++ b/twilio/rest/ip_messaging/v1/credential.py
@@ -53,7 +53,7 @@ class CredentialList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/ip_messaging/v1/service/__init__.py
+++ b/twilio/rest/ip_messaging/v1/service/__init__.py
@@ -72,7 +72,7 @@ class ServiceList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/ip_messaging/v1/service/channel/__init__.py
+++ b/twilio/rest/ip_messaging/v1/service/channel/__init__.py
@@ -83,7 +83,7 @@ class ChannelList(ListResource):
 
         page = self.page(type=type, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, type=values.unset, limit=None, page_size=None):
         """

--- a/twilio/rest/ip_messaging/v1/service/channel/invite.py
+++ b/twilio/rest/ip_messaging/v1/service/channel/invite.py
@@ -78,7 +78,7 @@ class InviteList(ListResource):
 
         page = self.page(identity=identity, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, identity=values.unset, limit=None, page_size=None):
         """

--- a/twilio/rest/ip_messaging/v1/service/channel/member.py
+++ b/twilio/rest/ip_messaging/v1/service/channel/member.py
@@ -78,7 +78,7 @@ class MemberList(ListResource):
 
         page = self.page(identity=identity, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, identity=values.unset, limit=None, page_size=None):
         """

--- a/twilio/rest/ip_messaging/v1/service/channel/message.py
+++ b/twilio/rest/ip_messaging/v1/service/channel/message.py
@@ -78,7 +78,7 @@ class MessageList(ListResource):
 
         page = self.page(order=order, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, order=values.unset, limit=None, page_size=None):
         """

--- a/twilio/rest/ip_messaging/v1/service/role.py
+++ b/twilio/rest/ip_messaging/v1/service/role.py
@@ -76,7 +76,7 @@ class RoleList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/ip_messaging/v1/service/user/__init__.py
+++ b/twilio/rest/ip_messaging/v1/service/user/__init__.py
@@ -79,7 +79,7 @@ class UserList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/ip_messaging/v1/service/user/user_channel.py
+++ b/twilio/rest/ip_messaging/v1/service/user/user_channel.py
@@ -54,7 +54,7 @@ class UserChannelList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/ip_messaging/v2/credential.py
+++ b/twilio/rest/ip_messaging/v2/credential.py
@@ -53,7 +53,7 @@ class CredentialList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/ip_messaging/v2/service/__init__.py
+++ b/twilio/rest/ip_messaging/v2/service/__init__.py
@@ -73,7 +73,7 @@ class ServiceList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/ip_messaging/v2/service/binding.py
+++ b/twilio/rest/ip_messaging/v2/service/binding.py
@@ -58,7 +58,7 @@ class BindingList(ListResource):
 
         page = self.page(binding_type=binding_type, identity=identity, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, binding_type=values.unset, identity=values.unset, limit=None,
              page_size=None):

--- a/twilio/rest/ip_messaging/v2/service/channel/__init__.py
+++ b/twilio/rest/ip_messaging/v2/service/channel/__init__.py
@@ -94,7 +94,7 @@ class ChannelList(ListResource):
 
         page = self.page(type=type, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, type=values.unset, limit=None, page_size=None):
         """

--- a/twilio/rest/ip_messaging/v2/service/channel/invite.py
+++ b/twilio/rest/ip_messaging/v2/service/channel/invite.py
@@ -78,7 +78,7 @@ class InviteList(ListResource):
 
         page = self.page(identity=identity, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, identity=values.unset, limit=None, page_size=None):
         """

--- a/twilio/rest/ip_messaging/v2/service/channel/member.py
+++ b/twilio/rest/ip_messaging/v2/service/channel/member.py
@@ -97,7 +97,7 @@ class MemberList(ListResource):
 
         page = self.page(identity=identity, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, identity=values.unset, limit=None, page_size=None):
         """

--- a/twilio/rest/ip_messaging/v2/service/channel/message.py
+++ b/twilio/rest/ip_messaging/v2/service/channel/message.py
@@ -96,7 +96,7 @@ class MessageList(ListResource):
 
         page = self.page(order=order, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, order=values.unset, limit=None, page_size=None):
         """

--- a/twilio/rest/ip_messaging/v2/service/channel/webhook.py
+++ b/twilio/rest/ip_messaging/v2/service/channel/webhook.py
@@ -56,7 +56,7 @@ class WebhookList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/ip_messaging/v2/service/role.py
+++ b/twilio/rest/ip_messaging/v2/service/role.py
@@ -76,7 +76,7 @@ class RoleList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/ip_messaging/v2/service/user/__init__.py
+++ b/twilio/rest/ip_messaging/v2/service/user/__init__.py
@@ -82,7 +82,7 @@ class UserList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/ip_messaging/v2/service/user/user_binding.py
+++ b/twilio/rest/ip_messaging/v2/service/user/user_binding.py
@@ -57,7 +57,7 @@ class UserBindingList(ListResource):
 
         page = self.page(binding_type=binding_type, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, binding_type=values.unset, limit=None, page_size=None):
         """

--- a/twilio/rest/ip_messaging/v2/service/user/user_channel.py
+++ b/twilio/rest/ip_messaging/v2/service/user/user_channel.py
@@ -56,7 +56,7 @@ class UserChannelList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/messaging/v1/service/__init__.py
+++ b/twilio/rest/messaging/v1/service/__init__.py
@@ -106,7 +106,7 @@ class ServiceList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/messaging/v1/service/alpha_sender.py
+++ b/twilio/rest/messaging/v1/service/alpha_sender.py
@@ -70,7 +70,7 @@ class AlphaSenderList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/messaging/v1/service/phone_number.py
+++ b/twilio/rest/messaging/v1/service/phone_number.py
@@ -70,7 +70,7 @@ class PhoneNumberList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/messaging/v1/service/short_code.py
+++ b/twilio/rest/messaging/v1/service/short_code.py
@@ -70,7 +70,7 @@ class ShortCodeList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/monitor/v1/alert.py
+++ b/twilio/rest/monitor/v1/alert.py
@@ -63,7 +63,7 @@ class AlertList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, log_level=values.unset, start_date=values.unset,
              end_date=values.unset, limit=None, page_size=None):

--- a/twilio/rest/monitor/v1/event.py
+++ b/twilio/rest/monitor/v1/event.py
@@ -71,7 +71,7 @@ class EventList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, actor_sid=values.unset, event_type=values.unset,
              resource_sid=values.unset, source_ip_address=values.unset,

--- a/twilio/rest/notify/v1/credential.py
+++ b/twilio/rest/notify/v1/credential.py
@@ -54,7 +54,7 @@ class CredentialList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/notify/v1/service/__init__.py
+++ b/twilio/rest/notify/v1/service/__init__.py
@@ -104,7 +104,7 @@ class ServiceList(ListResource):
 
         page = self.page(friendly_name=friendly_name, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, friendly_name=values.unset, limit=None, page_size=None):
         """

--- a/twilio/rest/notify/v1/service/binding.py
+++ b/twilio/rest/notify/v1/service/binding.py
@@ -98,7 +98,7 @@ class BindingList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, start_date=values.unset, end_date=values.unset,
              identity=values.unset, tag=values.unset, limit=None, page_size=None):

--- a/twilio/rest/numbers/v2/regulatory_compliance/bundle/__init__.py
+++ b/twilio/rest/numbers/v2/regulatory_compliance/bundle/__init__.py
@@ -100,7 +100,7 @@ class BundleList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, status=values.unset, friendly_name=values.unset,
              regulation_sid=values.unset, iso_country=values.unset,

--- a/twilio/rest/numbers/v2/regulatory_compliance/bundle/evaluation.py
+++ b/twilio/rest/numbers/v2/regulatory_compliance/bundle/evaluation.py
@@ -65,7 +65,7 @@ class EvaluationList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/numbers/v2/regulatory_compliance/bundle/item_assignment.py
+++ b/twilio/rest/numbers/v2/regulatory_compliance/bundle/item_assignment.py
@@ -69,7 +69,7 @@ class ItemAssignmentList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/numbers/v2/regulatory_compliance/end_user.py
+++ b/twilio/rest/numbers/v2/regulatory_compliance/end_user.py
@@ -75,7 +75,7 @@ class EndUserList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/numbers/v2/regulatory_compliance/end_user_type.py
+++ b/twilio/rest/numbers/v2/regulatory_compliance/end_user_type.py
@@ -52,7 +52,7 @@ class EndUserTypeList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/numbers/v2/regulatory_compliance/regulation.py
+++ b/twilio/rest/numbers/v2/regulatory_compliance/regulation.py
@@ -61,7 +61,7 @@ class RegulationList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, end_user_type=values.unset, iso_country=values.unset,
              number_type=values.unset, limit=None, page_size=None):

--- a/twilio/rest/numbers/v2/regulatory_compliance/supporting_document.py
+++ b/twilio/rest/numbers/v2/regulatory_compliance/supporting_document.py
@@ -75,7 +75,7 @@ class SupportingDocumentList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/numbers/v2/regulatory_compliance/supporting_document_type.py
+++ b/twilio/rest/numbers/v2/regulatory_compliance/supporting_document_type.py
@@ -52,7 +52,7 @@ class SupportingDocumentTypeList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/preview/bulk_exports/export/day.py
+++ b/twilio/rest/preview/bulk_exports/export/day.py
@@ -63,7 +63,7 @@ class DayList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, next_token=values.unset, previous_token=values.unset, limit=None,
              page_size=None):

--- a/twilio/rest/preview/bulk_exports/export/export_custom_job.py
+++ b/twilio/rest/preview/bulk_exports/export/export_custom_job.py
@@ -61,7 +61,7 @@ class ExportCustomJobList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, next_token=values.unset, previous_token=values.unset, limit=None,
              page_size=None):

--- a/twilio/rest/preview/deployed_devices/fleet/__init__.py
+++ b/twilio/rest/preview/deployed_devices/fleet/__init__.py
@@ -74,7 +74,7 @@ class FleetList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/preview/deployed_devices/fleet/certificate.py
+++ b/twilio/rest/preview/deployed_devices/fleet/certificate.py
@@ -79,7 +79,7 @@ class CertificateList(ListResource):
 
         page = self.page(device_sid=device_sid, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, device_sid=values.unset, limit=None, page_size=None):
         """

--- a/twilio/rest/preview/deployed_devices/fleet/deployment.py
+++ b/twilio/rest/preview/deployed_devices/fleet/deployment.py
@@ -72,7 +72,7 @@ class DeploymentList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/preview/deployed_devices/fleet/device.py
+++ b/twilio/rest/preview/deployed_devices/fleet/device.py
@@ -84,7 +84,7 @@ class DeviceList(ListResource):
 
         page = self.page(deployment_sid=deployment_sid, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, deployment_sid=values.unset, limit=None, page_size=None):
         """

--- a/twilio/rest/preview/deployed_devices/fleet/key.py
+++ b/twilio/rest/preview/deployed_devices/fleet/key.py
@@ -73,7 +73,7 @@ class KeyList(ListResource):
 
         page = self.page(device_sid=device_sid, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, device_sid=values.unset, limit=None, page_size=None):
         """

--- a/twilio/rest/preview/hosted_numbers/authorization_document/__init__.py
+++ b/twilio/rest/preview/hosted_numbers/authorization_document/__init__.py
@@ -60,7 +60,7 @@ class AuthorizationDocumentList(ListResource):
 
         page = self.page(email=email, status=status, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, email=values.unset, status=values.unset, limit=None,
              page_size=None):

--- a/twilio/rest/preview/hosted_numbers/authorization_document/dependent_hosted_number_order.py
+++ b/twilio/rest/preview/hosted_numbers/authorization_document/dependent_hosted_number_order.py
@@ -69,7 +69,7 @@ class DependentHostedNumberOrderList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, status=values.unset, phone_number=values.unset,
              incoming_phone_number_sid=values.unset, friendly_name=values.unset,

--- a/twilio/rest/preview/hosted_numbers/hosted_number_order.py
+++ b/twilio/rest/preview/hosted_numbers/hosted_number_order.py
@@ -70,7 +70,7 @@ class HostedNumberOrderList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, status=values.unset, phone_number=values.unset,
              incoming_phone_number_sid=values.unset, friendly_name=values.unset,

--- a/twilio/rest/preview/marketplace/available_add_on/__init__.py
+++ b/twilio/rest/preview/marketplace/available_add_on/__init__.py
@@ -55,7 +55,7 @@ class AvailableAddOnList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/preview/marketplace/available_add_on/available_add_on_extension.py
+++ b/twilio/rest/preview/marketplace/available_add_on/available_add_on_extension.py
@@ -55,7 +55,7 @@ class AvailableAddOnExtensionList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/preview/marketplace/installed_add_on/__init__.py
+++ b/twilio/rest/preview/marketplace/installed_add_on/__init__.py
@@ -81,7 +81,7 @@ class InstalledAddOnList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/preview/marketplace/installed_add_on/installed_add_on_extension.py
+++ b/twilio/rest/preview/marketplace/installed_add_on/installed_add_on_extension.py
@@ -55,7 +55,7 @@ class InstalledAddOnExtensionList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/preview/sync/service/__init__.py
+++ b/twilio/rest/preview/sync/service/__init__.py
@@ -83,7 +83,7 @@ class ServiceList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/preview/sync/service/document/__init__.py
+++ b/twilio/rest/preview/sync/service/document/__init__.py
@@ -74,7 +74,7 @@ class DocumentList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/preview/sync/service/document/document_permission.py
+++ b/twilio/rest/preview/sync/service/document/document_permission.py
@@ -56,7 +56,7 @@ class DocumentPermissionList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/preview/sync/service/sync_list/__init__.py
+++ b/twilio/rest/preview/sync/service/sync_list/__init__.py
@@ -73,7 +73,7 @@ class SyncListList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/preview/sync/service/sync_list/sync_list_item.py
+++ b/twilio/rest/preview/sync/service/sync_list/sync_list_item.py
@@ -82,7 +82,7 @@ class SyncListItemList(ListResource):
 
         page = self.page(order=order, from_=from_, bounds=bounds, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, order=values.unset, from_=values.unset, bounds=values.unset,
              limit=None, page_size=None):

--- a/twilio/rest/preview/sync/service/sync_list/sync_list_permission.py
+++ b/twilio/rest/preview/sync/service/sync_list/sync_list_permission.py
@@ -56,7 +56,7 @@ class SyncListPermissionList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/preview/sync/service/sync_map/__init__.py
+++ b/twilio/rest/preview/sync/service/sync_map/__init__.py
@@ -73,7 +73,7 @@ class SyncMapList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/preview/sync/service/sync_map/sync_map_item.py
+++ b/twilio/rest/preview/sync/service/sync_map/sync_map_item.py
@@ -83,7 +83,7 @@ class SyncMapItemList(ListResource):
 
         page = self.page(order=order, from_=from_, bounds=bounds, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, order=values.unset, from_=values.unset, bounds=values.unset,
              limit=None, page_size=None):

--- a/twilio/rest/preview/sync/service/sync_map/sync_map_permission.py
+++ b/twilio/rest/preview/sync/service/sync_map/sync_map_permission.py
@@ -56,7 +56,7 @@ class SyncMapPermissionList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/preview/understand/assistant/__init__.py
+++ b/twilio/rest/preview/understand/assistant/__init__.py
@@ -64,7 +64,7 @@ class AssistantList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/preview/understand/assistant/field_type/__init__.py
+++ b/twilio/rest/preview/understand/assistant/field_type/__init__.py
@@ -57,7 +57,7 @@ class FieldTypeList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/preview/understand/assistant/field_type/field_value.py
+++ b/twilio/rest/preview/understand/assistant/field_type/field_value.py
@@ -58,7 +58,7 @@ class FieldValueList(ListResource):
 
         page = self.page(language=language, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, language=values.unset, limit=None, page_size=None):
         """

--- a/twilio/rest/preview/understand/assistant/model_build.py
+++ b/twilio/rest/preview/understand/assistant/model_build.py
@@ -56,7 +56,7 @@ class ModelBuildList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/preview/understand/assistant/query.py
+++ b/twilio/rest/preview/understand/assistant/query.py
@@ -65,7 +65,7 @@ class QueryList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, language=values.unset, model_build=values.unset,
              status=values.unset, limit=None, page_size=None):

--- a/twilio/rest/preview/understand/assistant/task/__init__.py
+++ b/twilio/rest/preview/understand/assistant/task/__init__.py
@@ -61,7 +61,7 @@ class TaskList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/preview/understand/assistant/task/field.py
+++ b/twilio/rest/preview/understand/assistant/task/field.py
@@ -57,7 +57,7 @@ class FieldList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/preview/understand/assistant/task/sample.py
+++ b/twilio/rest/preview/understand/assistant/task/sample.py
@@ -58,7 +58,7 @@ class SampleList(ListResource):
 
         page = self.page(language=language, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, language=values.unset, limit=None, page_size=None):
         """

--- a/twilio/rest/preview/wireless/command.py
+++ b/twilio/rest/preview/wireless/command.py
@@ -66,7 +66,7 @@ class CommandList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, device=values.unset, sim=values.unset, status=values.unset,
              direction=values.unset, limit=None, page_size=None):

--- a/twilio/rest/preview/wireless/rate_plan.py
+++ b/twilio/rest/preview/wireless/rate_plan.py
@@ -56,7 +56,7 @@ class RatePlanList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/preview/wireless/sim/__init__.py
+++ b/twilio/rest/preview/wireless/sim/__init__.py
@@ -70,7 +70,7 @@ class SimList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, status=values.unset, iccid=values.unset, rate_plan=values.unset,
              e_id=values.unset, sim_registration_code=values.unset, limit=None,

--- a/twilio/rest/pricing/v1/messaging/country.py
+++ b/twilio/rest/pricing/v1/messaging/country.py
@@ -52,7 +52,7 @@ class CountryList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/pricing/v1/phone_number/country.py
+++ b/twilio/rest/pricing/v1/phone_number/country.py
@@ -52,7 +52,7 @@ class CountryList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/pricing/v1/voice/country.py
+++ b/twilio/rest/pricing/v1/voice/country.py
@@ -52,7 +52,7 @@ class CountryList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/pricing/v2/voice/country.py
+++ b/twilio/rest/pricing/v2/voice/country.py
@@ -52,7 +52,7 @@ class CountryList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/proxy/v1/service/__init__.py
+++ b/twilio/rest/proxy/v1/service/__init__.py
@@ -57,7 +57,7 @@ class ServiceList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/proxy/v1/service/phone_number.py
+++ b/twilio/rest/proxy/v1/service/phone_number.py
@@ -73,7 +73,7 @@ class PhoneNumberList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/proxy/v1/service/session/__init__.py
+++ b/twilio/rest/proxy/v1/service/session/__init__.py
@@ -58,7 +58,7 @@ class SessionList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/proxy/v1/service/session/interaction.py
+++ b/twilio/rest/proxy/v1/service/session/interaction.py
@@ -56,7 +56,7 @@ class InteractionList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/proxy/v1/service/session/participant/__init__.py
+++ b/twilio/rest/proxy/v1/service/session/participant/__init__.py
@@ -57,7 +57,7 @@ class ParticipantList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/proxy/v1/service/session/participant/message_interaction.py
+++ b/twilio/rest/proxy/v1/service/session/participant/message_interaction.py
@@ -84,7 +84,7 @@ class MessageInteractionList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/proxy/v1/service/short_code.py
+++ b/twilio/rest/proxy/v1/service/short_code.py
@@ -70,7 +70,7 @@ class ShortCodeList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/serverless/v1/service/__init__.py
+++ b/twilio/rest/serverless/v1/service/__init__.py
@@ -59,7 +59,7 @@ class ServiceList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/serverless/v1/service/asset/__init__.py
+++ b/twilio/rest/serverless/v1/service/asset/__init__.py
@@ -57,7 +57,7 @@ class AssetList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/serverless/v1/service/asset/asset_version.py
+++ b/twilio/rest/serverless/v1/service/asset/asset_version.py
@@ -57,7 +57,7 @@ class AssetVersionList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/serverless/v1/service/build.py
+++ b/twilio/rest/serverless/v1/service/build.py
@@ -57,7 +57,7 @@ class BuildList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/serverless/v1/service/environment/__init__.py
+++ b/twilio/rest/serverless/v1/service/environment/__init__.py
@@ -59,7 +59,7 @@ class EnvironmentList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/serverless/v1/service/environment/deployment.py
+++ b/twilio/rest/serverless/v1/service/environment/deployment.py
@@ -57,7 +57,7 @@ class DeploymentList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/serverless/v1/service/environment/log.py
+++ b/twilio/rest/serverless/v1/service/environment/log.py
@@ -67,7 +67,7 @@ class LogList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, function_sid=values.unset, start_date=values.unset,
              end_date=values.unset, limit=None, page_size=None):

--- a/twilio/rest/serverless/v1/service/environment/variable.py
+++ b/twilio/rest/serverless/v1/service/environment/variable.py
@@ -57,7 +57,7 @@ class VariableList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/serverless/v1/service/function/__init__.py
+++ b/twilio/rest/serverless/v1/service/function/__init__.py
@@ -57,7 +57,7 @@ class FunctionList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/serverless/v1/service/function/function_version/__init__.py
+++ b/twilio/rest/serverless/v1/service/function/function_version/__init__.py
@@ -58,7 +58,7 @@ class FunctionVersionList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/studio/v1/flow/__init__.py
+++ b/twilio/rest/studio/v1/flow/__init__.py
@@ -55,7 +55,7 @@ class FlowList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/studio/v1/flow/engagement/__init__.py
+++ b/twilio/rest/studio/v1/flow/engagement/__init__.py
@@ -57,7 +57,7 @@ class EngagementList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/studio/v1/flow/engagement/step/__init__.py
+++ b/twilio/rest/studio/v1/flow/engagement/step/__init__.py
@@ -56,7 +56,7 @@ class StepList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/studio/v1/flow/execution/__init__.py
+++ b/twilio/rest/studio/v1/flow/execution/__init__.py
@@ -64,7 +64,7 @@ class ExecutionList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, date_created_from=values.unset, date_created_to=values.unset,
              limit=None, page_size=None):

--- a/twilio/rest/studio/v1/flow/execution/execution_step/__init__.py
+++ b/twilio/rest/studio/v1/flow/execution/execution_step/__init__.py
@@ -56,7 +56,7 @@ class ExecutionStepList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/studio/v2/flow/__init__.py
+++ b/twilio/rest/studio/v2/flow/__init__.py
@@ -82,7 +82,7 @@ class FlowList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/studio/v2/flow/execution/__init__.py
+++ b/twilio/rest/studio/v2/flow/execution/__init__.py
@@ -65,7 +65,7 @@ class ExecutionList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, date_created_from=values.unset, date_created_to=values.unset,
              limit=None, page_size=None):

--- a/twilio/rest/studio/v2/flow/execution/execution_step/__init__.py
+++ b/twilio/rest/studio/v2/flow/execution/execution_step/__init__.py
@@ -57,7 +57,7 @@ class ExecutionStepList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/studio/v2/flow/flow_revision.py
+++ b/twilio/rest/studio/v2/flow/flow_revision.py
@@ -55,7 +55,7 @@ class FlowRevisionList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/supersim/v1/command.py
+++ b/twilio/rest/supersim/v1/command.py
@@ -83,7 +83,7 @@ class CommandList(ListResource):
 
         page = self.page(sim=sim, status=status, direction=direction, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, sim=values.unset, status=values.unset, direction=values.unset,
              limit=None, page_size=None):

--- a/twilio/rest/supersim/v1/fleet.py
+++ b/twilio/rest/supersim/v1/fleet.py
@@ -89,7 +89,7 @@ class FleetList(ListResource):
 
         page = self.page(network_access_profile=network_access_profile, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, network_access_profile=values.unset, limit=None, page_size=None):
         """

--- a/twilio/rest/supersim/v1/network.py
+++ b/twilio/rest/supersim/v1/network.py
@@ -58,7 +58,7 @@ class NetworkList(ListResource):
 
         page = self.page(iso_country=iso_country, mcc=mcc, mnc=mnc, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, iso_country=values.unset, mcc=values.unset, mnc=values.unset,
              limit=None, page_size=None):

--- a/twilio/rest/supersim/v1/network_access_profile/__init__.py
+++ b/twilio/rest/supersim/v1/network_access_profile/__init__.py
@@ -73,7 +73,7 @@ class NetworkAccessProfileList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/supersim/v1/network_access_profile/network_access_profile_network.py
+++ b/twilio/rest/supersim/v1/network_access_profile/network_access_profile_network.py
@@ -55,7 +55,7 @@ class NetworkAccessProfileNetworkList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/supersim/v1/sim.py
+++ b/twilio/rest/supersim/v1/sim.py
@@ -59,7 +59,7 @@ class SimList(ListResource):
 
         page = self.page(status=status, fleet=fleet, iccid=iccid, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, status=values.unset, fleet=values.unset, iccid=values.unset,
              limit=None, page_size=None):

--- a/twilio/rest/supersim/v1/usage_record.py
+++ b/twilio/rest/supersim/v1/usage_record.py
@@ -67,7 +67,7 @@ class UsageRecordList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, sim=values.unset, granularity=values.unset,
              start_time=values.unset, end_time=values.unset, limit=None,

--- a/twilio/rest/sync/v1/service/__init__.py
+++ b/twilio/rest/sync/v1/service/__init__.py
@@ -91,7 +91,7 @@ class ServiceList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/sync/v1/service/document/__init__.py
+++ b/twilio/rest/sync/v1/service/document/__init__.py
@@ -74,7 +74,7 @@ class DocumentList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/sync/v1/service/document/document_permission.py
+++ b/twilio/rest/sync/v1/service/document/document_permission.py
@@ -55,7 +55,7 @@ class DocumentPermissionList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/sync/v1/service/sync_list/__init__.py
+++ b/twilio/rest/sync/v1/service/sync_list/__init__.py
@@ -75,7 +75,7 @@ class SyncListList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/sync/v1/service/sync_list/sync_list_item.py
+++ b/twilio/rest/sync/v1/service/sync_list/sync_list_item.py
@@ -90,7 +90,7 @@ class SyncListItemList(ListResource):
 
         page = self.page(order=order, from_=from_, bounds=bounds, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, order=values.unset, from_=values.unset, bounds=values.unset,
              limit=None, page_size=None):

--- a/twilio/rest/sync/v1/service/sync_list/sync_list_permission.py
+++ b/twilio/rest/sync/v1/service/sync_list/sync_list_permission.py
@@ -55,7 +55,7 @@ class SyncListPermissionList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/sync/v1/service/sync_map/__init__.py
+++ b/twilio/rest/sync/v1/service/sync_map/__init__.py
@@ -75,7 +75,7 @@ class SyncMapList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/sync/v1/service/sync_map/sync_map_item.py
+++ b/twilio/rest/sync/v1/service/sync_map/sync_map_item.py
@@ -92,7 +92,7 @@ class SyncMapItemList(ListResource):
 
         page = self.page(order=order, from_=from_, bounds=bounds, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, order=values.unset, from_=values.unset, bounds=values.unset,
              limit=None, page_size=None):

--- a/twilio/rest/sync/v1/service/sync_map/sync_map_permission.py
+++ b/twilio/rest/sync/v1/service/sync_map/sync_map_permission.py
@@ -55,7 +55,7 @@ class SyncMapPermissionList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/sync/v1/service/sync_stream/__init__.py
+++ b/twilio/rest/sync/v1/service/sync_stream/__init__.py
@@ -72,7 +72,7 @@ class SyncStreamList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/taskrouter/v1/workspace/__init__.py
+++ b/twilio/rest/taskrouter/v1/workspace/__init__.py
@@ -64,7 +64,7 @@ class WorkspaceList(ListResource):
 
         page = self.page(friendly_name=friendly_name, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, friendly_name=values.unset, limit=None, page_size=None):
         """

--- a/twilio/rest/taskrouter/v1/workspace/activity.py
+++ b/twilio/rest/taskrouter/v1/workspace/activity.py
@@ -57,7 +57,7 @@ class ActivityList(ListResource):
 
         page = self.page(friendly_name=friendly_name, available=available, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, friendly_name=values.unset, available=values.unset, limit=None,
              page_size=None):

--- a/twilio/rest/taskrouter/v1/workspace/event.py
+++ b/twilio/rest/taskrouter/v1/workspace/event.py
@@ -84,7 +84,7 @@ class EventList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, end_date=values.unset, event_type=values.unset,
              minutes=values.unset, reservation_sid=values.unset,

--- a/twilio/rest/taskrouter/v1/workspace/task/__init__.py
+++ b/twilio/rest/taskrouter/v1/workspace/task/__init__.py
@@ -80,7 +80,7 @@ class TaskList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, priority=values.unset, assignment_status=values.unset,
              workflow_sid=values.unset, workflow_name=values.unset,

--- a/twilio/rest/taskrouter/v1/workspace/task/reservation.py
+++ b/twilio/rest/taskrouter/v1/workspace/task/reservation.py
@@ -57,7 +57,7 @@ class ReservationList(ListResource):
 
         page = self.page(reservation_status=reservation_status, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, reservation_status=values.unset, limit=None, page_size=None):
         """

--- a/twilio/rest/taskrouter/v1/workspace/task_channel.py
+++ b/twilio/rest/taskrouter/v1/workspace/task_channel.py
@@ -54,7 +54,7 @@ class TaskChannelList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/taskrouter/v1/workspace/task_queue/__init__.py
+++ b/twilio/rest/taskrouter/v1/workspace/task_queue/__init__.py
@@ -71,7 +71,7 @@ class TaskQueueList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, friendly_name=values.unset,
              evaluate_worker_attributes=values.unset, worker_sid=values.unset,

--- a/twilio/rest/taskrouter/v1/workspace/task_queue/task_queues_statistics.py
+++ b/twilio/rest/taskrouter/v1/workspace/task_queue/task_queues_statistics.py
@@ -70,7 +70,7 @@ class TaskQueuesStatisticsList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, end_date=values.unset, friendly_name=values.unset,
              minutes=values.unset, start_date=values.unset,

--- a/twilio/rest/taskrouter/v1/workspace/worker/__init__.py
+++ b/twilio/rest/taskrouter/v1/workspace/worker/__init__.py
@@ -82,7 +82,7 @@ class WorkerList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, activity_name=values.unset, activity_sid=values.unset,
              available=values.unset, friendly_name=values.unset,

--- a/twilio/rest/taskrouter/v1/workspace/worker/reservation.py
+++ b/twilio/rest/taskrouter/v1/workspace/worker/reservation.py
@@ -57,7 +57,7 @@ class ReservationList(ListResource):
 
         page = self.page(reservation_status=reservation_status, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, reservation_status=values.unset, limit=None, page_size=None):
         """

--- a/twilio/rest/taskrouter/v1/workspace/worker/worker_channel.py
+++ b/twilio/rest/taskrouter/v1/workspace/worker/worker_channel.py
@@ -55,7 +55,7 @@ class WorkerChannelList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/taskrouter/v1/workspace/workflow/__init__.py
+++ b/twilio/rest/taskrouter/v1/workspace/workflow/__init__.py
@@ -58,7 +58,7 @@ class WorkflowList(ListResource):
 
         page = self.page(friendly_name=friendly_name, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, friendly_name=values.unset, limit=None, page_size=None):
         """

--- a/twilio/rest/trunking/v1/trunk/__init__.py
+++ b/twilio/rest/trunking/v1/trunk/__init__.py
@@ -89,7 +89,7 @@ class TrunkList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/trunking/v1/trunk/credential_list.py
+++ b/twilio/rest/trunking/v1/trunk/credential_list.py
@@ -69,7 +69,7 @@ class CredentialListList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/trunking/v1/trunk/ip_access_control_list.py
+++ b/twilio/rest/trunking/v1/trunk/ip_access_control_list.py
@@ -69,7 +69,7 @@ class IpAccessControlListList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/trunking/v1/trunk/origination_url.py
+++ b/twilio/rest/trunking/v1/trunk/origination_url.py
@@ -79,7 +79,7 @@ class OriginationUrlList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/trunking/v1/trunk/phone_number.py
+++ b/twilio/rest/trunking/v1/trunk/phone_number.py
@@ -69,7 +69,7 @@ class PhoneNumberList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/verify/v2/service/__init__.py
+++ b/twilio/rest/verify/v2/service/__init__.py
@@ -95,7 +95,7 @@ class ServiceList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/verify/v2/service/entity/__init__.py
+++ b/twilio/rest/verify/v2/service/entity/__init__.py
@@ -75,7 +75,7 @@ class EntityList(ListResource):
 
         page = self.page(twilio_sandbox_mode=twilio_sandbox_mode, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, twilio_sandbox_mode=values.unset, limit=None, page_size=None):
         """

--- a/twilio/rest/verify/v2/service/entity/factor/__init__.py
+++ b/twilio/rest/verify/v2/service/entity/factor/__init__.py
@@ -91,7 +91,7 @@ class FactorList(ListResource):
 
         page = self.page(twilio_sandbox_mode=twilio_sandbox_mode, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, twilio_sandbox_mode=values.unset, limit=None, page_size=None):
         """

--- a/twilio/rest/verify/v2/service/entity/factor/challenge.py
+++ b/twilio/rest/verify/v2/service/entity/factor/challenge.py
@@ -96,7 +96,7 @@ class ChallengeList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, status=values.unset, twilio_sandbox_mode=values.unset,
              limit=None, page_size=None):

--- a/twilio/rest/verify/v2/service/messaging_configuration.py
+++ b/twilio/rest/verify/v2/service/messaging_configuration.py
@@ -74,7 +74,7 @@ class MessagingConfigurationList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/verify/v2/service/rate_limit/__init__.py
+++ b/twilio/rest/verify/v2/service/rate_limit/__init__.py
@@ -71,7 +71,7 @@ class RateLimitList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/verify/v2/service/rate_limit/bucket.py
+++ b/twilio/rest/verify/v2/service/rate_limit/bucket.py
@@ -76,7 +76,7 @@ class BucketList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/video/v1/composition/__init__.py
+++ b/twilio/rest/video/v1/composition/__init__.py
@@ -68,7 +68,7 @@ class CompositionList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, status=values.unset, date_created_after=values.unset,
              date_created_before=values.unset, room_sid=values.unset, limit=None,

--- a/twilio/rest/video/v1/composition_hook.py
+++ b/twilio/rest/video/v1/composition_hook.py
@@ -68,7 +68,7 @@ class CompositionHookList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, enabled=values.unset, date_created_after=values.unset,
              date_created_before=values.unset, friendly_name=values.unset,

--- a/twilio/rest/video/v1/recording/__init__.py
+++ b/twilio/rest/video/v1/recording/__init__.py
@@ -71,7 +71,7 @@ class RecordingList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, status=values.unset, source_sid=values.unset,
              grouping_sid=values.unset, date_created_after=values.unset,

--- a/twilio/rest/video/v1/room/__init__.py
+++ b/twilio/rest/video/v1/room/__init__.py
@@ -105,7 +105,7 @@ class RoomList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, status=values.unset, unique_name=values.unset,
              date_created_after=values.unset, date_created_before=values.unset,

--- a/twilio/rest/video/v1/room/recording/__init__.py
+++ b/twilio/rest/video/v1/room/recording/__init__.py
@@ -67,7 +67,7 @@ class RoomRecordingList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, status=values.unset, source_sid=values.unset,
              date_created_after=values.unset, date_created_before=values.unset,

--- a/twilio/rest/video/v1/room/room_participant/__init__.py
+++ b/twilio/rest/video/v1/room/room_participant/__init__.py
@@ -70,7 +70,7 @@ class ParticipantList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, status=values.unset, identity=values.unset,
              date_created_after=values.unset, date_created_before=values.unset,

--- a/twilio/rest/video/v1/room/room_participant/room_participant_published_track.py
+++ b/twilio/rest/video/v1/room/room_participant/room_participant_published_track.py
@@ -55,7 +55,7 @@ class PublishedTrackList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/video/v1/room/room_participant/room_participant_subscribed_track.py
+++ b/twilio/rest/video/v1/room/room_participant/room_participant_subscribed_track.py
@@ -55,7 +55,7 @@ class SubscribedTrackList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/voice/v1/byoc_trunk.py
+++ b/twilio/rest/voice/v1/byoc_trunk.py
@@ -93,7 +93,7 @@ class ByocTrunkList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/voice/v1/connection_policy/__init__.py
+++ b/twilio/rest/voice/v1/connection_policy/__init__.py
@@ -69,7 +69,7 @@ class ConnectionPolicyList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/voice/v1/connection_policy/connection_policy_target.py
+++ b/twilio/rest/voice/v1/connection_policy/connection_policy_target.py
@@ -84,7 +84,7 @@ class ConnectionPolicyTargetList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/voice/v1/dialing_permissions/country/__init__.py
+++ b/twilio/rest/voice/v1/dialing_permissions/country/__init__.py
@@ -73,7 +73,7 @@ class CountryList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, iso_code=values.unset, continent=values.unset,
              country_code=values.unset, low_risk_numbers_enabled=values.unset,

--- a/twilio/rest/voice/v1/dialing_permissions/country/highrisk_special_prefix.py
+++ b/twilio/rest/voice/v1/dialing_permissions/country/highrisk_special_prefix.py
@@ -54,7 +54,7 @@ class HighriskSpecialPrefixList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/voice/v1/ip_record.py
+++ b/twilio/rest/voice/v1/ip_record.py
@@ -75,7 +75,7 @@ class IpRecordList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/voice/v1/source_ip_mapping.py
+++ b/twilio/rest/voice/v1/source_ip_mapping.py
@@ -69,7 +69,7 @@ class SourceIpMappingList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/wireless/v1/command.py
+++ b/twilio/rest/wireless/v1/command.py
@@ -64,7 +64,7 @@ class CommandList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, sim=values.unset, status=values.unset, direction=values.unset,
              transport=values.unset, limit=None, page_size=None):

--- a/twilio/rest/wireless/v1/rate_plan.py
+++ b/twilio/rest/wireless/v1/rate_plan.py
@@ -54,7 +54,7 @@ class RatePlanList(ListResource):
 
         page = self.page(page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, limit=None, page_size=None):
         """

--- a/twilio/rest/wireless/v1/sim/__init__.py
+++ b/twilio/rest/wireless/v1/sim/__init__.py
@@ -69,7 +69,7 @@ class SimList(ListResource):
             page_size=limits['page_size'],
         )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, status=values.unset, iccid=values.unset, rate_plan=values.unset,
              e_id=values.unset, sim_registration_code=values.unset, limit=None,

--- a/twilio/rest/wireless/v1/sim/data_session.py
+++ b/twilio/rest/wireless/v1/sim/data_session.py
@@ -57,7 +57,7 @@ class DataSessionList(ListResource):
 
         page = self.page(end=end, start=start, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, end=values.unset, start=values.unset, limit=None,
              page_size=None):

--- a/twilio/rest/wireless/v1/sim/usage_record.py
+++ b/twilio/rest/wireless/v1/sim/usage_record.py
@@ -57,7 +57,7 @@ class UsageRecordList(ListResource):
 
         page = self.page(end=end, start=start, granularity=granularity, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, end=values.unset, start=values.unset, granularity=values.unset,
              limit=None, page_size=None):

--- a/twilio/rest/wireless/v1/usage_record.py
+++ b/twilio/rest/wireless/v1/usage_record.py
@@ -56,7 +56,7 @@ class UsageRecordList(ListResource):
 
         page = self.page(end=end, start=start, granularity=granularity, page_size=limits['page_size'], )
 
-        return self._version.stream(page, limits['limit'], limits['page_limit'])
+        return self._version.stream(page, limits['limit'])
 
     def list(self, end=values.unset, start=values.unset, granularity=values.unset,
              limit=None, page_size=None):


### PR DESCRIPTION
A calculated page limit doesn't really make sense since it is only calculated when a record limit is also used. If we have a record limit, then a calculated page limit is not needed.