### PR TITLE
fix: drop the page limit calculation and correct the page limit stop condition

### DIFF
--- a/tests/unit/base/test_version.py
+++ b/tests/unit/base/test_version.py
@@ -13,7 +13,6 @@ class TestPage(Page):
 
 
 class VersionTestCase(IntegrationTestCase):
-
     def setUp(self):
         super(VersionTestCase, self).setUp()
 

--- a/tests/unit/base/test_version.py
+++ b/tests/unit/base/test_version.py
@@ -1,0 +1,67 @@
+from tests import IntegrationTestCase
+from tests.holodeck import Request
+from twilio.base.page import Page
+from twilio.http.response import Response
+
+
+class TestPage(Page):
+    def __init__(self, version, response, *_args, **_kwargs):
+        super(TestPage, self).__init__(version, response)
+
+    def get_instance(self, payload):
+        return payload
+
+
+class VersionTestCase(IntegrationTestCase):
+
+    def setUp(self):
+        super(VersionTestCase, self).setUp()
+
+        self.holodeck.mock(Response(
+            200,
+            '''
+            {
+                "next_page_uri": "/2010-04-01/Accounts/AC123/Messages.json?Page=1",
+                "messages": [{"body": "payload0"}, {"body": "payload1"}]
+            }
+            '''
+        ), Request(url='https://api.twilio.com/2010-04-01/Accounts/AC123/Messages.json'))
+
+        self.holodeck.mock(Response(
+            200,
+            '''
+            {
+                "next_page_uri": "/2010-04-01/Accounts/AC123/Messages.json?Page=2",
+                "messages": [{"body": "payload2"}, {"body": "payload3"}]
+            }
+            '''
+        ), Request(url='https://api.twilio.com/2010-04-01/Accounts/AC123/Messages.json?Page=1'))
+
+        self.holodeck.mock(Response(
+            200,
+            '''
+            {
+                "next_page_uri": null,
+                "messages": [{"body": "payload4"}]
+            }
+            '''
+        ), Request(url='https://api.twilio.com/2010-04-01/Accounts/AC123/Messages.json?Page=2'))
+
+        self.version = self.client.api.v2010
+        self.response = self.version.page(method='GET', uri='/Accounts/AC123/Messages.json')
+        self.page = TestPage(self.version, self.response)
+
+    def test_stream(self):
+        messages = list(self.version.stream(self.page))
+
+        self.assertEqual(len(messages), 5)
+
+    def test_stream_limit(self):
+        messages = list(self.version.stream(self.page, limit=3))
+
+        self.assertEqual(len(messages), 3)
+
+    def test_stream_page_limit(self):
+        messages = list(self.version.stream(self.page, page_limit=1))
+
+        self.assertEqual(len(messages), 2)

--- a/twilio/base/version.py
+++ b/twilio/base/version.py
@@ -61,7 +61,8 @@ class Version(object):
             code = error_payload.get('code', response.status_code)
             return TwilioRestException(response.status_code, uri, message, code, method, details)
         except Exception:
-            return TwilioRestException(response.status_code, uri, message, response.status_code, method)
+            return TwilioRestException(response.status_code, uri, message, response.status_code,
+                                       method)
 
     def fetch(self, method, uri, params=None, data=None, headers=None, auth=None, timeout=None,
               allow_redirects=False):
@@ -135,19 +136,12 @@ class Version(object):
         :param int page_size: Max page size.
         :return dict: A dictionary of paging limits.
         """
-        page_limit = values.unset
-
-        if limit is not None:
-
-            if page_size is None:
-                page_size = limit
-
-            page_limit = int(ceil(limit / float(page_size)))
+        if limit is not None and page_size is None:
+            page_size = limit
 
         return {
             'limit': limit or values.unset,
             'page_size': page_size or values.unset,
-            'page_limit': page_limit,
         }
 
     def page(self, method, uri, params=None, data=None, headers=None, auth=None, timeout=None,
@@ -172,7 +166,7 @@ class Version(object):
 
         :param Page page: The page to stream.
         :param int limit: The max number of records to read.
-        :param int page_imit: The max number of pages to read.
+        :param int page_limit: The max number of pages to read.
         """
         current_record = 1
         current_page = 1
@@ -184,11 +178,11 @@ class Version(object):
                 if limit and limit is not values.unset and limit < current_record:
                     return
 
+            current_page += 1
             if page_limit and page_limit is not values.unset and page_limit < current_page:
                 return
 
             page = page.next_page()
-            current_page += 1
 
     def create(self, method, uri, params=None, data=None, headers=None, auth=None, timeout=None,
                allow_redirects=False):


### PR DESCRIPTION
Dropping the page limit calculation since it's no longer used and doesn't make sense to be calculated on a record limit. Also correct the page limit stop logic (with added tests) where an extra page was being queried.