### PR TITLE
fix: allow API redirect responses

### DIFF
--- a/tests/unit/base/test_version.py
+++ b/tests/unit/base/test_version.py
@@ -12,9 +12,9 @@ class TestPage(Page):
         return payload
 
 
-class VersionTestCase(IntegrationTestCase):
+class StreamTestCase(IntegrationTestCase):
     def setUp(self):
-        super(VersionTestCase, self).setUp()
+        super(StreamTestCase, self).setUp()
 
         self.holodeck.mock(Response(
             200,
@@ -64,3 +64,17 @@ class VersionTestCase(IntegrationTestCase):
         messages = list(self.version.stream(self.page, page_limit=1))
 
         self.assertEqual(len(messages), 2)
+
+
+class VersionTestCase(IntegrationTestCase):
+    def test_fetch_redirect(self):
+        self.holodeck.mock(Response(
+            307,
+            '{"redirect_to": "some_place"}'
+        ), Request(url='https://messaging.twilio.com/v1/Deactivations'))
+        response = self.client.messaging.v1.fetch(
+            method='GET',
+            uri='/Deactivations'
+        )
+
+        self.assertIsNotNone(response)

--- a/twilio/base/version.py
+++ b/twilio/base/version.py
@@ -80,7 +80,8 @@ class Version(object):
             allow_redirects=allow_redirects,
         )
 
-        if response.status_code < 200 or response.status_code >= 300:
+        # Note that 3XX response codes are allowed for fetches.
+        if response.status_code < 200 or response.status_code >= 400:
             raise self.exception(method, uri, response, 'Unable to fetch record')
 
         return json.loads(response.text)


### PR DESCRIPTION
Fetching a BulkExport for a single day returns a `307` with the AWS URL for the file. With this change, the URL will now be included in the response.

Fixes https://github.com/twilio/twilio-python/issues/531