### PR TITLE
fix: pin pyjwt dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ mock
 nose
 six
 requests>=2.0.0
-PyJWT>=1.4.2
+PyJWT==1.7.1
 twine


### PR DESCRIPTION
# Fixes #

#551

Long term solution would be to support version 2.X (note that this is a breaking change)

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license

