### PR TITLE
fix!: update code and tests for pyjwt>=2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ mock
 nose
 six
 requests>=2.0.0
-PyJWT==1.7.1
+PyJWT>=2.0.0
 twine

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     install_requires=[
         "six",
         "pytz",
-        "PyJWT == 1.7.1",
+        "PyJWT >= 2.0.0",
     ],
     extras_require={
         ':python_version<"3.0"': [

--- a/tests/unit/jwt/test_jwt.py
+++ b/tests/unit/jwt/test_jwt.py
@@ -43,7 +43,7 @@ class JwtTest(unittest.TestCase):
         expected_headers = expected_headers or {}
         expected_payload = expected_payload or {}
 
-        decoded_payload = jwt_lib.decode(jwt, key, verify=False)
+        decoded_payload = jwt_lib.decode(jwt, key, algorithms=["HS256"], options={"verify_signature":False})
         decoded_headers = jwt_lib.get_unverified_header(jwt)
 
         self.assertEqual(expected_headers, decoded_headers)
@@ -242,9 +242,8 @@ class JwtTest(unittest.TestCase):
 
     def test_decode_modified_jwt_fails(self):
         jwt = DummyJwt('secret_key', 'issuer')
-        example_jwt = jwt.to_jwt().decode('utf-8')
+        example_jwt = jwt.to_jwt()
         example_jwt = 'ABC' + example_jwt[3:]
-        example_jwt = example_jwt.encode('utf-8')
 
         self.assertRaises(JwtDecodeError, Jwt.from_jwt, example_jwt, 'secret_key')
 

--- a/twilio/jwt/__init__.py
+++ b/twilio/jwt/__init__.py
@@ -140,7 +140,8 @@ class Jwt(object):
         verify = True if key else False
 
         try:
-            payload = jwt_lib.decode(bytes(jwt), key, options={
+            alg = jwt_lib.get_unverified_header(jwt).get("alg", "HS256")
+            payload = jwt_lib.decode(jwt, key, algorithms=[alg], options={
                 'verify_signature': verify,
                 'verify_exp': True,
                 'verify_nbf': True,


### PR DESCRIPTION
# Fixes #556 

This PR upgrades pyjwt to 2.0.1, which is a major version upgrade and a breaking change. Namely, pyjwt 2.x drops support for Python 2.x and Python 3.0-3.5. It also changes some user-facing APIs that require changes to twilio-python.

I've made a start on updating the code and fixing broken tests. It would be great to get feedback on the changes in `twilio/jwt/__init__.py:143-144`. Since the `algorithms` kwarg is now a required argument for `jwt.decode(...)` and this library uses both HS256 and RS256, the approach I've taken is to try and get the appropriate algorithm from the particular token's header and fall back to HS256 if it's missing. The alternative approach would be to explicitly pass in `algorithms=["HS256", "RS256"]` without trying to get the algorithm from the header.

That's as far as the "easy" changes go. The harder decision is dropping support for older Python versions and what kind of changes that requires. Happy to help, but I'd need guidance.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-python/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified
