### PR TITLE
chore: removed file exec to get version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,6 @@
 from __future__ import with_statement
 from setuptools import setup, find_packages
 
-__version__ = None
-with open('twilio/__init__.py') as f:
-    exec(f.read())
-
 with open('README.md') as f:
     long_description = f.read()
 
@@ -18,7 +14,7 @@ with open('README.md') as f:
 
 setup(
     name="twilio",
-    version=__version__,
+    version="6.52.0",
     description="Twilio API client and TwiML generator",
     author="Twilio",
     author_email="help@twilio.com",


### PR DESCRIPTION
Simplifying logic to populate the _version_ in setup.py by moving it to librarian

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-python/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

[Related PR](https://code.hq.twilio.com/twilio/librarian/pull/259)
