### PR TITLE
test: Pinning ubuntu version for python 3.6 test runs

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -13,11 +13,17 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
       matrix:
-        python-version: [ '3.6', '3.7', '3.8', '3.9', '3.10' ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
+        os: [ubuntu-latest]
+        # Need to pin ubuntu version for python 3.6 (see https://github.com/actions/setup-python/issues/544#issuecomment-1332535877)
+        # Change this to use ubuntu-latest for all python versions after deprecating python 3.6
+        include:
+          - python-version: '3.6'
+            os: 'ubuntu-20.04'
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout twilio-python
         uses: actions/checkout@v3


### PR DESCRIPTION
Recent test runs [are failing](https://github.com/twilio/twilio-python/actions/runs/3649444667) due to latest ubuntu images dropping python 3.6. This PR pins an older ubuntu version for python 3.6. We should revert this when we deprecate 3.6.