### PR TITLE
chore: drop support for python 3.6

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -13,17 +13,11 @@ on:
 jobs:
   test:
     name: Test
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
       matrix:
         python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
-        os: [ubuntu-latest]
-        # Need to pin ubuntu version for python 3.6 (see https://github.com/actions/setup-python/issues/544#issuecomment-1332535877)
-        # Change this to use ubuntu-latest for all python versions after deprecating python 3.6
-        include:
-          - python-version: '3.6'
-            os: 'ubuntu-20.04'
-    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout twilio-python
         uses: actions/checkout@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.7
 
 ENV PYTHONUNBUFFERED 1
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: clean install analysis test test-install test-docker develop docs docs-install
 
 venv:
-	@python --version || (echo "Python is not installed, Python 3.6+"; exit 1);
+	@python --version || (echo "Python is not installed, Python 3.7+"; exit 1);
 	virtualenv --python=python venv
 
 install: venv

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Please consult the [official migration guide](https://www.twilio.com/docs/librar
 
 This library supports the following Python implementations:
 
-* Python 3.6
 * Python 3.7
 * Python 3.8
 * Python 3.9

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     author_email="help@twilio.com",
     url="https://github.com/twilio/twilio-python/",
     keywords=["twilio", "twiml"],
-    python_requires='>=3.6.0',
+    python_requires='>=3.7.0',
     install_requires=[
         "pytz",
         "requests >= 2.0.0",
@@ -33,7 +33,6 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3{6,7,8,9,10,11}, pypy
+envlist = py3{7,8,9,10,11}, pypy
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
Jira: [DI-1488](https://issues.corp.twilio.com/browse/DI-1488)
This PR drops support for Python version 3.6. Python 3.7 will be the new required minimum version to use the twilio-python helper library.