### PR TITLE
chore: use older verison of aiohttp_retry

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ pygments>=2.7.4 # not directly required, pinned by Snyk to avoid a vulnerability
 requests>=2.31.0
 PyJWT>=2.0.0, <3.0.0
 aiohttp>=3.9.4
-aiohttp-retry>=2.8.3
+aiohttp-retry==2.8.3
 certifi>=2023.7.22 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
# Fixes #
https://github.com/inyutin/aiohttp_retry/
has released a latest version because of that we are getting error in our sdk build pipeline.

`
self = <aiohttp_retry.client._RequestContext object at 0x7f4176598d90>
--
  | current_attempt = 1
  | response = <tests.unit.http.test_async_http_client.MockResponse object at 0x7f4176516c50>
  |  
  | async def _is_skip_retry(self, current_attempt: int, response: ClientResponse) -> bool:
  | if current_attempt == self._retry_options.attempts:
  | return True
  |  
  | >       if response.method not in self._retry_options.methods:
  | E       AttributeError: 'MockResponse' object has no attribute 'method'

`

Fix:
Using older version and created an issue in aiohttp_retry repo.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [ ] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-python/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [ ] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
