### PR TITLE
fix: Resolve setuptools warnings

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,1 @@
-# Include the SSL certificate file in the package distributed by pip
-recursive-include twilio/conf *
 include LICENSE

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 universal = 1
 
 [metadata]
-description-file = README.md
+description_file = README.md
 license = MIT
 
 [flake8]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal = 1
-
 [metadata]
 description_file = README.md
 license = MIT

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,9 @@ setup(
     version="9.5.0",
     description="Twilio API client and TwiML generator",
     author="Twilio",
-    help_center="https://www.twilio.com/help/contact",
+    project_urls={
+        "Help Center": "https://www.twilio.com/help/contact",
+    },
     url="https://github.com/twilio/twilio-python/",
     keywords=["twilio", "twiml"],
     python_requires=">=3.7.0",

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ setup(
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
-        "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
Resolve these warnings from `PYTHONDEVMODE=1 uv build`:

```
…/lib/python3.12/site-packages/setuptools/dist.py:493: SetuptoolsDeprecationWarning: Invalid dash-separated options
!!

        ********************************************************************************
        Usage of dash-separated 'description-file' will not be supported in future
        versions. Please use the underscore name 'description_file' instead.

        This deprecation is overdue, please update your project and remove deprecated
        calls to avoid build errors in the future.

        See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html for details.
        ********************************************************************************

!!
  opt = self.warn_dash_deprecation(opt, section)
```

```
…/lib/python3.12/site-packages/setuptools/_distutils/dist.py:270: UserWarning: Unknown distribution option: 'help_center'
  warnings.warn(msg)
```

```
…/lib/python3.12/site-packages/setuptools/_distutils/cmd.py:124: SetuptoolsDeprecationWarning: bdist_wheel.universal is deprecated
!!

        ********************************************************************************
        With Python 2.7 end-of-life, support for building universal wheels
        (i.e., wheels that support both Python 2 and Python 3)
        is being obviated.
        Please discontinue using this option, or if you still need it,
        file an issue with pypa/setuptools describing your use case.

        By 2025-Aug-30, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.
        ********************************************************************************

!!
  self.finalize_options()
```

```
…/lib/python3.12/site-packages/setuptools/dist.py:751: SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: MIT License

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
  self._finalize_license_expression()
```

```
warning: no files found matching '*' under directory 'twilio/conf'
```

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-python/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
