### PR TITLE
test: drop aiounittest in favor of stdlib IsolatedAsyncioTestCase

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,7 +2,6 @@ Sphinx>=1.8.0
 mock
 pytest
 pytest-cov
-aiounittest
 flake8
 wheel>=0.22.0
 cryptography

--- a/tests/unit/base/test_version.py
+++ b/tests/unit/base/test_version.py
@@ -1,7 +1,6 @@
 import unittest
 from unittest.mock import Mock
 
-import aiounittest
 from tests import IntegrationTestCase
 from tests.holodeck import Request
 from twilio.base.version import Version
@@ -791,7 +790,7 @@ class ResponseInfoIntegrationTestCase(IntegrationTestCase):
         self.assertIsInstance(headers, dict)
 
 
-class AsyncVersionTestCase(aiounittest.AsyncTestCase):
+class AsyncVersionTestCase(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         from tests.holodeck import AsyncHolodeck
         from twilio.rest import Client

--- a/tests/unit/http/test_async_http_client.py
+++ b/tests/unit/http/test_async_http_client.py
@@ -1,4 +1,4 @@
-import aiounittest
+import unittest
 
 from aiohttp import ClientSession
 from mock import patch, AsyncMock
@@ -20,7 +20,7 @@ class MockResponse(object):
         return self._text
 
 
-class TestAsyncHttpClientRequest(aiounittest.AsyncTestCase):
+class TestAsyncHttpClientRequest(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         self.session_mock = AsyncMock(wraps=ClientSession)
         self.session_mock.request.return_value = MockResponse("test", 200)
@@ -59,7 +59,7 @@ class TestAsyncHttpClientRequest(aiounittest.AsyncTestCase):
             await self.client.request("doesnt matter", "doesnt matter", timeout=-1)
 
 
-class TestAsyncHttpClientRetries(aiounittest.AsyncTestCase):
+class TestAsyncHttpClientRetries(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         self.session_mock = AsyncMock(wraps=ClientSession)
         self.session_mock.request.side_effect = [
@@ -92,7 +92,7 @@ class TestAsyncHttpClientRetries(aiounittest.AsyncTestCase):
         self.assertEqual(response.text, "Error")
 
 
-class TestAsyncHttpClientSession(aiounittest.AsyncTestCase):
+class TestAsyncHttpClientSession(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         self.session_patcher = patch("twilio.http.async_http_client.ClientSession")
         self.session_constructor_mock = self.session_patcher.start()

--- a/tests/unit/rest/test_client.py
+++ b/tests/unit/rest/test_client.py
@@ -1,7 +1,5 @@
 import unittest
 
-import aiounittest
-
 from mock import AsyncMock, Mock
 
 from twilio.http.response import Response
@@ -108,7 +106,7 @@ class TestUserAgentClients(unittest.TestCase):
         self.assertEqual(user_agent_extensions, expected_user_agent_extensions)
 
 
-class TestClientAsyncRequest(aiounittest.AsyncTestCase):
+class TestClientAsyncRequest(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         self.mock_async_http_client = AsyncMock()
         self.mock_async_http_client.request.return_value = Response(200, "test")


### PR DESCRIPTION
Fixes #916.

`aiounittest` has had no release since 2022 and the maintainer has confirmed it won't get Python 3.14 support ([kwarunek/aiounittest#28](https://github.com/kwarunek/aiounittest/issues/28)), which was blocking the test suite on 3.14.

Everything the test suite uses from `aiounittest` — specifically `aiounittest.AsyncTestCase` — has been in the stdlib since Python 3.8 as `unittest.IsolatedAsyncioTestCase`. The API is identical for our use: `async def test_*` methods + `setUp`/`tearDown`, no custom event-loop handling needed. So this is a straight import swap, no test-method changes.

### Changes

- `tests/requirements.txt` — remove `aiounittest`
- `tests/unit/http/test_async_http_client.py` — 3 classes
- `tests/unit/rest/test_client.py` — 1 class
- `tests/unit/base/test_version.py` — 1 class

### Local verification

Python 3.13 on Windows (3.14 not installed locally, but the substitution is a superset — `IsolatedAsyncioTestCase` works on 3.8+):

```
$ pytest tests/unit/
620 passed, 101 warnings in 7.02s
```

The 71 tests in the three touched files (`TestAsyncHttpClientRequest`, `TestAsyncHttpClientRetries`, `TestAsyncHttpClientSession`, `TestClientAsyncRequest`, `AsyncVersionTestCase`) all pass.
