### PR TITLE
fix(http): fall back to self.timeout in AsyncTwilioHttpClient.request

### DIFF
--- a/twilio/http/async_http_client.py
+++ b/twilio/http/async_http_client.py
@@ -76,7 +76,9 @@ class AsyncTwilioHttpClient(AsyncHttpClient):
 
         :return: An http response
         """
-        if timeout is not None and timeout <= 0:
+        if timeout is None:
+            timeout = self.timeout
+        elif timeout <= 0:
             raise ValueError(timeout)
 
         basic_auth = None


### PR DESCRIPTION
Fixes #925

`AsyncTwilioHttpClient.request` did not use `self.timeout` when the `timeout` parameter was `None`, unlike the sync `TwilioHttpClient`. The timeout set on the client was silently ignored in async usage.

Match the sync behavior: fall back to `self.timeout` when `timeout` is `None`.

**Before:**
```python
if timeout is not None and timeout <= 0:
    raise ValueError(timeout)
```

**After:**
```python
if timeout is None:
    timeout = self.timeout
elif timeout <= 0:
    raise ValueError(timeout)
```