### PR TITLE
fix: avoid deprecated aiohttp basic auth API

### DIFF
--- a/tests/unit/http/test_async_http_client.py
+++ b/tests/unit/http/test_async_http_client.py
@@ -1,3 +1,5 @@
+import warnings
+
 import aiounittest
 
 from aiohttp import ClientSession
@@ -43,16 +45,137 @@ class TestAsyncHttpClientRequest(aiounittest.AsyncTestCase):
         self.assertEqual(request_args["method"], "GET")
         self.assertEqual(request_args["url"], "https://mock.twilio.com")
 
-    async def test_request_called_with_basic_auth(self):
-        await self.client.request(
-            "doesnt matter", "doesnt matter", auth=("account_sid", "auth_token")
-        )
+    async def test_request_called_with_basic_auth_header_without_deprecation(self):
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "error",
+                message="BasicAuth is deprecated.*",
+                category=DeprecationWarning,
+            )
+            await self.client.request(
+                "doesnt matter",
+                "doesnt matter",
+                auth=("account_sid", "auth_token"),
+            )
 
         self.session_mock.request.assert_called()
-        auth = self.session_mock.request.call_args.kwargs["auth"]
-        self.assertIsNotNone(auth)
-        self.assertEqual(auth.login, "account_sid")
-        self.assertEqual(auth.password, "auth_token")
+        request_args = self.session_mock.request.call_args.kwargs
+        self.assertNotIn("auth", request_args)
+        self.assertEqual(
+            request_args["headers"]["Authorization"],
+            "Basic YWNjb3VudF9zaWQ6YXV0aF90b2tlbg==",
+        )
+
+    async def test_request_does_not_mutate_headers_when_adding_basic_auth(self):
+        headers = {"X-Test": "value"}
+
+        await self.client.request(
+            "doesnt matter",
+            "doesnt matter",
+            headers=headers,
+            auth=("account_sid", "auth_token"),
+        )
+
+        request_headers = self.session_mock.request.call_args.kwargs["headers"]
+        self.assertEqual(headers, {"X-Test": "value"})
+        self.assertIsNot(request_headers, headers)
+        self.assertEqual(request_headers["X-Test"], "value")
+        self.assertEqual(
+            request_headers["Authorization"],
+            "Basic YWNjb3VudF9zaWQ6YXV0aF90b2tlbg==",
+        )
+
+    async def test_request_preserves_latin1_basic_auth_encoding(self):
+        await self.client.request(
+            "doesnt matter", "doesnt matter", auth=("café", "päss")
+        )
+
+        request_headers = self.session_mock.request.call_args.kwargs["headers"]
+        self.assertEqual(request_headers["Authorization"], "Basic Y2Fm6Tpw5HNz")
+
+    async def test_request_accepts_empty_basic_auth_credentials(self):
+        await self.client.request("doesnt matter", "doesnt matter", auth=("", ""))
+
+        request_headers = self.session_mock.request.call_args.kwargs["headers"]
+        self.assertEqual(request_headers["Authorization"], "Basic Og==")
+
+    async def test_request_rejects_colon_in_basic_auth_username(self):
+        with self.assertRaises(ValueError):
+            await self.client.request(
+                "doesnt matter", "doesnt matter", auth=("account:sid", "auth_token")
+            )
+
+        self.session_mock.request.assert_not_called()
+
+    async def test_request_accepts_colon_in_basic_auth_password(self):
+        await self.client.request(
+            "doesnt matter", "doesnt matter", auth=("account_sid", "auth:token")
+        )
+
+        request_headers = self.session_mock.request.call_args.kwargs["headers"]
+        self.assertEqual(
+            request_headers["Authorization"],
+            "Basic YWNjb3VudF9zaWQ6YXV0aDp0b2tlbg==",
+        )
+
+    async def test_request_rejects_auth_with_authorization_header(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "Cannot combine AUTHORIZATION header with AUTH argument",
+        ):
+            await self.client.request(
+                "doesnt matter",
+                "doesnt matter",
+                headers={"authorization": "Bearer token"},
+                auth=("account_sid", "auth_token"),
+            )
+
+        self.session_mock.request.assert_not_called()
+
+    async def test_request_checks_auth_header_conflict_before_encoding(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "Cannot combine AUTHORIZATION header with AUTH argument",
+        ):
+            await self.client.request(
+                "doesnt matter",
+                "doesnt matter",
+                headers={"Authorization": "Bearer token"},
+                auth=("雪", "密"),
+            )
+
+        self.session_mock.request.assert_not_called()
+
+    async def test_request_preserves_authorization_header_without_auth(self):
+        headers = {"authorization": "Bearer token"}
+
+        await self.client.request("doesnt matter", "doesnt matter", headers=headers)
+
+        request_args = self.session_mock.request.call_args.kwargs
+        self.assertNotIn("auth", request_args)
+        self.assertEqual(request_args["headers"], headers)
+
+    async def test_request_preserves_basic_auth_none_validation(self):
+        with self.assertRaisesRegex(ValueError, "None is not allowed as login value"):
+            await self.client.request(
+                "doesnt matter", "doesnt matter", auth=(None, "auth_token")
+            )
+        with self.assertRaisesRegex(
+            ValueError, "None is not allowed as password value"
+        ):
+            await self.client.request(
+                "doesnt matter", "doesnt matter", auth=("account_sid", None)
+            )
+
+        self.session_mock.request.assert_not_called()
+
+    async def test_request_rejects_non_latin1_basic_auth_credentials(self):
+        with self.assertRaises(UnicodeEncodeError):
+            await self.client.request(
+                "doesnt matter", "doesnt matter", auth=("雪", "密")
+            )
+
+        self.session_mock.request.assert_not_called()
 
     async def test_invalid_request_timeout_raises_exception(self):
         with self.assertRaises(ValueError):

--- a/twilio/http/async_http_client.py
+++ b/twilio/http/async_http_client.py
@@ -1,14 +1,36 @@
 import logging
 from typing import Dict, Optional, Tuple
 
-from aiohttp import BasicAuth, ClientSession
+from aiohttp import ClientSession
 from aiohttp_retry import ExponentialRetry, RetryClient
 
 from twilio.http import AsyncHttpClient
 from twilio.http.request import Request as TwilioRequest
 from twilio.http.response import Response
 
+try:
+    from aiohttp import encode_basic_auth as _aiohttp_encode_basic_auth
+except ImportError:
+    from aiohttp import BasicAuth
+
+    def _aiohttp_encode_basic_auth(
+        login: str, password: str = "", encoding: str = "utf-8"
+    ) -> str:
+        """Encode Basic Auth credentials on aiohttp versions before 3.14."""
+        return BasicAuth(login=login, password=password, encoding=encoding).encode()
+
+
 _logger = logging.getLogger("twilio.async_http_client")
+
+
+def _validate_basic_auth(login: str, password: str) -> None:
+    """Validate Basic Auth credentials using aiohttp's legacy rules."""
+    if login is None:
+        raise ValueError("None is not allowed as login value")
+    if password is None:
+        raise ValueError("None is not allowed as password value")
+    if ":" in login:
+        raise ValueError('A ":" is not allowed in login (RFC 1945#section-11.1)')
 
 
 class AsyncTwilioHttpClient(AsyncHttpClient):
@@ -79,17 +101,28 @@ class AsyncTwilioHttpClient(AsyncHttpClient):
         if timeout is not None and timeout <= 0:
             raise ValueError(timeout)
 
-        basic_auth = None
+        request_headers = headers
         if auth is not None:
-            basic_auth = BasicAuth(login=auth[0], password=auth[1])
+            _validate_basic_auth(auth[0], auth[1])
+            if headers is not None and any(
+                name.lower() == "authorization" for name in headers
+            ):
+                raise ValueError(
+                    "Cannot combine AUTHORIZATION header "
+                    "with AUTH argument or credentials encoded in URL"
+                )
+            authorization = _aiohttp_encode_basic_auth(
+                auth[0], auth[1], encoding="latin1"
+            )
+            request_headers = headers.copy() if headers is not None else {}
+            request_headers["Authorization"] = authorization
 
         kwargs = {
             "method": method.upper(),
             "url": url,
             "params": params,
             "data": data,
-            "headers": headers,
-            "auth": basic_auth,
+            "headers": request_headers,
             "timeout": timeout,
             "allow_redirects": allow_redirects,
         }
@@ -104,7 +137,7 @@ class AsyncTwilioHttpClient(AsyncHttpClient):
         else:
             session = ClientSession()
             temp = True
-        self._test_only_last_request = TwilioRequest(**kwargs)
+        self._test_only_last_request = TwilioRequest(auth=None, **kwargs)
         response = await session.request(**kwargs)
         self.log_response(response.status, response)
         self._test_only_last_response = Response(


### PR DESCRIPTION
# Fixes

Fixes #931

Replace the deprecated aiohttp `BasicAuth` / `auth=` request path with an `Authorization` header in `AsyncTwilioHttpClient`.

The implementation feature-detects `encode_basic_auth` so the declared `aiohttp>=3.8.4` range remains supported, explicitly preserves the historical Latin-1 wire encoding, rejects conflicting Authorization headers case-insensitively, and does not mutate caller-provided headers. The network call no longer passes the `auth` keyword, which also avoids the second aiohttp 3.14 deprecation and remains compatible with its planned removal in aiohttp 4.

### Validation

- Python 3.9.6 + aiohttp 3.8.4: 17 focused tests passed
- Python 3.14.6 + aiohttp 3.14.3: 17 focused tests passed
- Real local aiohttp request with aiohttp deprecations treated as errors: passed
- Full non-cluster suite: 639 tests passed
- `make analysis`: passed
- Changed-file Black, Autoflake, and `git diff --check`: passed

`make test` reaches the repository-wide Black check and stops on the pre-existing formatting of `tests/unit/rest/test_client.py`. That file is unchanged from `main`; the complete pytest suite and both Flake8 commands were run separately as listed above.

### Checklist

- [x] I acknowledge that all my contributions will be made under the project license
- [x] I have made a material change to the repo
- [x] I have read the Contribution Guidelines and this PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove the fix is effective
- [x] No user-facing documentation is needed because the public API and authentication behavior are unchanged
- [x] I have documented the compatibility helper added by this change