### PR TITLE
fix: use the client timeout in AsyncTwilioHttpClient when none is passed

### DIFF
--- a/tests/unit/http/test_async_http_client.py
+++ b/tests/unit/http/test_async_http_client.py
@@ -58,6 +58,22 @@ class TestAsyncHttpClientRequest(aiounittest.AsyncTestCase):
         with self.assertRaises(ValueError):
             await self.client.request("doesnt matter", "doesnt matter", timeout=-1)
 
+    async def test_request_uses_client_timeout_when_none_passed(self):
+        self.client.timeout = 30
+        await self.client.request("GET", "https://mock.twilio.com")
+
+        self.session_mock.request.assert_called()
+        request_args = self.session_mock.request.call_args.kwargs
+        self.assertEqual(request_args["timeout"], 30)
+
+    async def test_request_timeout_overrides_client_timeout(self):
+        self.client.timeout = 30
+        await self.client.request("GET", "https://mock.twilio.com", timeout=15)
+
+        self.session_mock.request.assert_called()
+        request_args = self.session_mock.request.call_args.kwargs
+        self.assertEqual(request_args["timeout"], 15)
+
 
 class TestAsyncHttpClientRetries(aiounittest.AsyncTestCase):
     def setUp(self):

--- a/twilio/http/async_http_client.py
+++ b/twilio/http/async_http_client.py
@@ -76,7 +76,9 @@ class AsyncTwilioHttpClient(AsyncHttpClient):
 
         :return: An http response
         """
-        if timeout is not None and timeout <= 0:
+        if timeout is None:
+            timeout = self.timeout
+        elif timeout <= 0:
             raise ValueError(timeout)
 
         basic_auth = None


### PR DESCRIPTION
Fixes #925

AsyncTwilioHttpClient.request ignored the timeout set on the client when the request did not pass one. The sync client already falls back to the client timeout in that case.

This matches that behavior and adds unit tests that check the timeout passed to aiohttp.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the Contribution Guidelines and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified