### PR TITLE
Fix unset sentinel comparison in values.of

### DIFF
--- a/tests/unit/base/test_values.py
+++ b/tests/unit/base/test_values.py
@@ -1,0 +1,34 @@
+from twilio.base.values import of, unset
+
+
+def test_of_removes_unset_values():
+    result = of(
+        {
+            "foo": "bar",
+            "unset": unset,
+        }
+    )
+
+    assert result == {
+        "foo": "bar",
+    }
+
+
+class EqualToUnset:
+    def __eq__(self, other):
+        return other is unset
+
+
+def test_of_only_removes_unset_sentinel():
+    value = EqualToUnset()
+
+    result = of(
+        {
+            "value": value,
+            "unset": unset,
+        }
+    )
+
+    assert result == {
+        "value": value,
+    }

--- a/twilio/base/values.py
+++ b/twilio/base/values.py
@@ -10,4 +10,4 @@ def of(d: Dict[str, object]) -> Dict[str, object]:
     :param d: A dict to strip.
     :return A dict with unset values removed.
     """
-    return {k: v for k, v in d.items() if v != unset}
+    return {k: v for k, v in d.items() if v is not unset}


### PR DESCRIPTION
# Fixes #

N/A

Fix `values.of()` so that it removes only the actual `unset` sentinel object.

The previous implementation used equality comparison (`!=`), which could incorrectly remove values that compare equal to `unset` without actually being the `unset` sentinel.

This change uses identity comparison (`is not`) instead.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-python/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified