### PR TITLE
fix: JSON-serialize async HTTP bodies for application/json

### DIFF
--- a/tests/unit/http/test_async_http_client.py
+++ b/tests/unit/http/test_async_http_client.py
@@ -58,6 +58,48 @@ class TestAsyncHttpClientRequest(aiounittest.AsyncTestCase):
         with self.assertRaises(ValueError):
             await self.client.request("doesnt matter", "doesnt matter", timeout=-1)
 
+    async def test_json_content_type_puts_dict_on_json_not_data(self):
+        payload = {"profile": {"logo_url": "https://example.com/x.jpg"}}
+        await self.client.request(
+            "POST",
+            "https://messaging.twilio.com/v2/Channels/Senders/XE123",
+            data=payload,
+            headers={"Content-Type": "application/json"},
+        )
+
+        self.session_mock.request.assert_called()
+        request_args = self.session_mock.request.call_args.kwargs
+        self.assertEqual(request_args["json"], payload)
+        self.assertNotIn("data", request_args)
+
+    async def test_scim_json_content_type_puts_dict_on_json_not_data(self):
+        payload = {"userName": "alice"}
+        await self.client.request(
+            "POST",
+            "https://preview.twilio.com/scim/Users",
+            data=payload,
+            headers={"Content-Type": "application/scim+json"},
+        )
+
+        self.session_mock.request.assert_called()
+        request_args = self.session_mock.request.call_args.kwargs
+        self.assertEqual(request_args["json"], payload)
+        self.assertNotIn("data", request_args)
+
+    async def test_form_content_type_puts_dict_on_data_not_json(self):
+        payload = {"To": "+15555555555", "Body": "hi"}
+        await self.client.request(
+            "POST",
+            "https://api.twilio.com/2010-04-01/Accounts/ACxxx/Messages.json",
+            data=payload,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+
+        self.session_mock.request.assert_called()
+        request_args = self.session_mock.request.call_args.kwargs
+        self.assertEqual(request_args["data"], payload)
+        self.assertNotIn("json", request_args)
+
 
 class TestAsyncHttpClientRetries(aiounittest.AsyncTestCase):
     def setUp(self):

--- a/twilio/http/async_http_client.py
+++ b/twilio/http/async_http_client.py
@@ -87,12 +87,17 @@ class AsyncTwilioHttpClient(AsyncHttpClient):
             "method": method.upper(),
             "url": url,
             "params": params,
-            "data": data,
             "headers": headers,
             "auth": basic_auth,
             "timeout": timeout,
             "allow_redirects": allow_redirects,
         }
+        if headers and headers.get("Content-Type") == "application/json":
+            kwargs["json"] = data
+        elif headers and headers.get("Content-Type") == "application/scim+json":
+            kwargs["json"] = data
+        else:
+            kwargs["data"] = data
 
         self.log_request(kwargs)
         self._test_only_last_response = None


### PR DESCRIPTION
`AsyncTwilioHttpClient.request` always passed the request body to aiohttp as `data=`, even when `Content-Type` was `application/json` or `application/scim+json`. aiohttp then form-encoded the dict, so JSON-body v2 endpoints (for example `messaging.v2.channels_senders(...).update_async(...)`) returned 400. The sync `TwilioHttpClient` already JSON-serializes those content types via `json=`.

This change mirrors that content-type branch in the async client.

Credits @adcore-dev for the report, the named files, and the suggested `json=` branch.

Fixes #932
